### PR TITLE
Add footers to PDF sections

### DIFF
--- a/app/domain/wsjrdp_2027/export/pdf/registration.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration.rb
@@ -31,7 +31,18 @@ module Wsjrdp2027
           @person = PersonDecorator.new(person)
 
           sections.each do |section|
+            pstart = pdf.page_number
+            current_section = section.name || ""
             section.new(pdf, @person).render
+            pend = pdf.page_number
+
+            pdf.repeat pstart..pend do
+              pdf.bounding_box [pdf.bounds.right - pdf.bounds.width / 2, pdf.bounds.bottom + 10],
+                width: pdf.bounds.width / 2 do
+                pdf.text_box current_section, align: :right
+              end
+            end
+
             pdf.start_new_page if section != sections.last
           end
 
@@ -81,14 +92,14 @@ module Wsjrdp2027
 
         def sections
           if ul?(@person)
-            return [Contract, Medical, Recommondation, DataProcessing, Foto, Travel]
+            return [Contract, Sepa, Medical, Recommondation, DataProcessing, Foto, Travel]
           end
 
           if cmt?(@person)
-            return [Contract, Medical, DataProcessing, Foto, Travel]
+            return [Contract, Sepa, Medical, DataProcessing, Foto, Travel]
           end
 
-          [Contract, Medical, Foto, Travel]
+          [Contract, Sepa, Medical, Foto, Travel]
         end
       end
       mattr_accessor :runner

--- a/app/domain/wsjrdp_2027/export/pdf/registration/contract.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration/contract.rb
@@ -5,6 +5,8 @@ module Wsjrdp2027
     class Contract < Section
       include ContractHelper
 
+      self.name = "Anmeldung"
+
       # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
       def render
         pdf.y = bounds.height - 60
@@ -106,68 +108,6 @@ module Wsjrdp2027
         pdf.move_down 3.mm
 
         signature.draw
-
-        pdf.start_new_page
-        pdf.move_down 3.mm
-        text "Was muss ich mit dem SEPA-Mandat machen?", size: 12
-        text "Das SEPA-Mandat muss"
-        text "1. vollständig unterschrieben werden"
-        text '2. auf anmeldung.worldscoutjamboree.de unter "Upload>SEPA hochladen" hochgeladen' \
-        + " werden"
-        text "3. am ersten Treffen der entsprechenden Betreuungsperson im Orginal überreicht werden"
-        pdf.move_down 3.mm
-        pdf.stroke_horizontal_rule
-        pdf.move_down 3.mm
-
-        text "SEPA-Mandat", size: 12
-
-        text "Die Teilnahmebeitrag zum Jamboree werden mittels SEPA-Basislastschrift eingezogen:"
-
-        pdf.move_down 3.mm
-        text "Ich ermächtige den Ring deutscher Pfadfinder*innenverbände e.V., die Zahlungen gemäß Zahlungsplan von meinem Konto mittels Lastschrift einzuziehen. Maßgeblich ist das von mir gewählte Zahlungsmodell (#{payment_role(@person).start_with?("EarlyPayer") ? "Einmalzahlung" : "Ratenzahlungen"}). Zugleich weise ich mein Kreditinstitut an, die vom Ring deutscher Pfadfinder*innenverbände e.V. auf mein Konto gezogenen Lastschriften einzulösen."
-
-        pdf.move_down 3.mm
-        text "Hinweis: Ich kann innerhalb von acht Wochen, beginnend mit dem Belastungsdatum, die Erstattung des belasteten Betrages verlangen."
-        text "Es gelten dabei die mit meinem Kreditinstitut vereinbarten Bedingungen."
-
-        pdf.move_down 3.mm
-        attendee_data = pdf.make_table([
-          [{content: "IBAN:", width: 150}, @person.sepa_iban],
-          ["Mandatsreferenz:", "wsjrdp2027" + @person.id.to_s],
-          ["Gläubiger*innen-Identifikationsnummer:",
-            "DE81 WSJ 0000 2017 275"], # Todo
-          ["Kontoinhaber*in:", @person.sepa_name],
-          ["Adresse:", @person.sepa_address]
-        ],
-          cell_style: {padding: 1, border_width: 0,
-                       inline_format: true})
-        attendee_data.draw
-
-        pdf.move_down 3.mm
-
-        if payment_role(@person).start_with?("EarlyPayer")
-          text "Der Einzug des Gesamtbetrages von #{payment_value(@person)} € erfolgt am 5. August 2025."
-        else
-          text "Der Einzug erfolgt am 5. des jeweiligen Monats bzw. am darauffolgenden Werktag nach folgendem Ratenplan:"
-          pdf.make_table(payment_array_table(@person), cell_style: {padding: 1,
-                                                                    border_width: 0,
-                                                                    inline_format: true,
-                                                                    size: 8}).draw
-        end
-
-        pdf.move_down 3.mm
-        text "Die Anzahlung wird frühestens nach dem Hochladen aller Anmeldeunterlagen eingezogen. Wir werden mindestens 7 Tage vor dem Einzug der Anzahlung über diesen informieren"
-        text "Im Falle einer Rücklastschrift behalten wir uns vor, die dadurch entstehenden Kosten an die*den Teilnehmer*in weiterzugeben."
-
-        pdf.move_down 3.mm
-        pdf.make_table([
-          [{content: @person.town + " den " + Time.zone.today.strftime("%d.%m.%Y"),
-            height: 30}],
-          ["______________________________", ""],
-          [{content: @person.sepa_name, height: 30}, ""]
-        ],
-          cell_style: {width: 240, padding: 1, border_width: 0,
-                       inline_format: true}).draw
 
         text ""
       end

--- a/app/domain/wsjrdp_2027/export/pdf/registration/data_processing.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration/data_processing.rb
@@ -3,6 +3,8 @@
 module Wsjrdp2027
   module Export::Pdf::Registration
     class DataProcessing < Section
+      self.name = "Vertraulichkeitsvereinbarung"
+
       # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
       def render
         pdf.y = bounds.height - 60

--- a/app/domain/wsjrdp_2027/export/pdf/registration/foto.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration/foto.rb
@@ -3,6 +3,8 @@
 module Wsjrdp2027
   module Export::Pdf::Registration
     class Foto < Section
+      self.name = "Fotoeinwilligung"
+
       # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
       def render
         pdf.y = bounds.height - 60

--- a/app/domain/wsjrdp_2027/export/pdf/registration/medical.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration/medical.rb
@@ -3,6 +3,8 @@
 module Wsjrdp2027
   module Export::Pdf::Registration
     class Medical < Section
+      self.name = "Medizinbogen"
+
       def render
         pdf.y = bounds.height - 60
         bounding_box([0, 230.mm], width: bounds.width, height: bounds.height - 210) do

--- a/app/domain/wsjrdp_2027/export/pdf/registration/recommondation.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration/recommondation.rb
@@ -3,6 +3,8 @@
 module Wsjrdp2027
   module Export::Pdf::Registration
     class Recommondation < Section
+      self.name = "Empfehlungsschreiben"
+
       # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
       def render
         pdf.y = bounds.height - 60

--- a/app/domain/wsjrdp_2027/export/pdf/registration/section.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration/section.rb
@@ -6,6 +6,7 @@ module Wsjrdp2027
       attr_reader :pdf
 
       class_attribute :model_class
+      class_attribute :name
 
       delegate :bounds, :bounding_box, :table,
         :text, :cursor, :font_size, :text_box,

--- a/app/domain/wsjrdp_2027/export/pdf/registration/sepa.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration/sepa.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Wsjrdp2027
+  module Export::Pdf::Registration
+    class Sepa < Section
+      include ContractHelper
+
+      self.name = "SEPA-Mandat"
+
+      # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
+      def render
+        pdf.y = bounds.height - 60
+        bounding_box([0, 230.mm], width: bounds.width, height: bounds.height - 210) do
+          font_size(8) do
+            text list, style: :italic, width: bounds.width
+          end
+        end
+      end
+
+      def list
+        text "Was muss ich mit dem SEPA-Mandat machen?", size: 12
+        text "Das SEPA-Mandat muss"
+        text "1. vollständig unterschrieben werden"
+        text '2. auf anmeldung.worldscoutjamboree.de unter "Upload>SEPA hochladen" hochgeladen' \
+        + " werden"
+        text "3. am ersten Treffen der entsprechenden Betreuungsperson im Orginal überreicht werden"
+        pdf.move_down 3.mm
+        pdf.stroke_horizontal_rule
+        pdf.move_down 3.mm
+
+        text "SEPA-Mandat", size: 12
+
+        text "Die Teilnahmebeitrag zum Jamboree werden mittels SEPA-Basislastschrift eingezogen:"
+
+        pdf.move_down 3.mm
+        text "Ich ermächtige den Ring deutscher Pfadfinder*innenverbände e.V., die Zahlungen gemäß Zahlungsplan von meinem Konto mittels Lastschrift einzuziehen. Maßgeblich ist das von mir gewählte Zahlungsmodell (#{payment_role(@person).start_with?("EarlyPayer") ? "Einmalzahlung" : "Ratenzahlungen"}). Zugleich weise ich mein Kreditinstitut an, die vom Ring deutscher Pfadfinder*innenverbände e.V. auf mein Konto gezogenen Lastschriften einzulösen."
+
+        pdf.move_down 3.mm
+        text "Hinweis: Ich kann innerhalb von acht Wochen, beginnend mit dem Belastungsdatum, die Erstattung des belasteten Betrages verlangen."
+        text "Es gelten dabei die mit meinem Kreditinstitut vereinbarten Bedingungen."
+
+        pdf.move_down 3.mm
+        attendee_data = pdf.make_table([
+          [{content: "IBAN:", width: 150}, @person.sepa_iban],
+          ["Mandatsreferenz:", "wsjrdp2027" + @person.id.to_s],
+          ["Gläubiger-Identifikationsnummer:",
+            "DE81 WSJ 0000 2017 275"], # Todo
+          ["Kontoinhaber*in:", @person.sepa_name],
+          ["Adresse:", @person.sepa_address]
+        ],
+          cell_style: {padding: 1, border_width: 0,
+                       inline_format: true})
+        attendee_data.draw
+
+        pdf.move_down 3.mm
+
+        if payment_role(@person).start_with?("EarlyPayer")
+          text "Der Einzug des Gesamtbetrages von #{payment_value(@person)} € erfolgt am 5. August 2025."
+        else
+          text "Der Einzug erfolgt am 5. des jeweiligen Monats bzw. am darauffolgenden Werktag nach folgendem Ratenplan:"
+          pdf.make_table(payment_array_table(@person), cell_style: {padding: 1,
+                                                                    border_width: 0,
+                                                                    inline_format: true,
+                                                                    size: 8}).draw
+        end
+
+        pdf.move_down 3.mm
+        text "Die Anzahlung wird frühestens nach dem Hochladen aller Anmeldeunterlagen eingezogen. Wir werden mindestens 7 Tage vor dem Einzug der Anzahlung über diesen informieren"
+        text "Im Falle einer Rücklastschrift behalten wir uns vor, die dadurch entstehenden Kosten an die*den Teilnehmer*in weiterzugeben."
+
+        pdf.move_down 3.mm
+        pdf.make_table([
+          [{content: @person.town + " den " + Time.zone.today.strftime("%d.%m.%Y"),
+            height: 30}],
+          ["______________________________", ""],
+          [{content: @person.sepa_name, height: 30}, ""]
+        ],
+          cell_style: {width: 240, padding: 1, border_width: 0,
+                       inline_format: true}).draw
+
+        text ""
+      end
+    end
+    # rubocop:enable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
+  end
+end

--- a/app/domain/wsjrdp_2027/export/pdf/registration/travel.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration/travel.rb
@@ -5,6 +5,8 @@ module Wsjrdp2027
     class Travel < Section
       include ContractHelper
 
+      self.name = "Teilnahme- und Reisebedingungen"
+
       # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity
       def render
         pdf.y = bounds.height - 60
@@ -195,7 +197,7 @@ module Wsjrdp2027
         pdf.move_down 3.mm
         text "9.3 Sollten einzelne Bestimmungen des Vertrages oder der vorliegenden Reisebedingungen unwirksam oder nichtig sein oder werden, so wird die Wirksamkeit des Vertrages und der übrigen Bedingungen hiervon nicht berührt. Die Parteien werden in einem solchen Fall unter Berücksichtigung des Gesetzes eine Vereinbarung treffen, die der unwirksamen oder nichtigen Klausel wirtschaftlich nahekommt. Das gleiche soll für den Fall gelten, dass im Vertrag eine Regelungslücke offenbar wird."
 
-        pdf.move_down 10.mm
+        pdf.start_new_page
         text "Hinweise zur Datenverarbeitung", size: 12
 
         pdf.move_down 3.mm


### PR DESCRIPTION
To make the pages of the different sections identifiable, add the section names to the footer of the page. To be able to set the footer of the SEPA in the same way, SEPA is now its own section. Sections without a name would not have the footer field filled. 

While already touching the SEPA, fix the gender of "Gläubiger*innen-Identifikationsnummer": in our case, rdp (der rdp, der Ring, der Verein) is the "Gläubiger". No need for other gender identities here.