### PR TITLE
Show more years in birthday datepicker (CMT-328)

### DIFF
--- a/app/views/wizards/steps/_new_user_form.html.haml
+++ b/app/views/wizards/steps/_new_user_form.html.haml
@@ -4,7 +4,7 @@
 
 = c.fields_for do |ff|
   = ff.labeled_input_fields :first_name, :last_name
-  = ff.labeled_date_field :birthday
+  = ff.labeled_date_field :birthday, yearRange: "1900:+0"
   = ff.labeled_input_field :email, help_inline: t('people.email_field.used_as_login'), class: 'd-inline'
 
   - if f.object.steps.one?
@@ -18,4 +18,4 @@
 %br/
 = link_to t('layouts.unauthorized.main_other_registration_info_text'), t('layouts.unauthorized.main_other_registration_info_link')
 %br/
-%br/ 
+%br/


### PR DESCRIPTION
Instead of just -10 to +10 years, show all years from 1900 to this year. While any date with the current year will be invalid for participation because of age restrictions, this makes sure the initially selected year in the date picker is 2025 instead of 1900 (default is to select the first when the current year is not in the range). This way, most participants only need to scroll a few years back.