### PR TITLE
Buddy ID validation (CMT-319)

### DIFF
--- a/app/controllers/person/print_controller.rb
+++ b/app/controllers/person/print_controller.rb
@@ -22,7 +22,7 @@ class Person::PrintController < ApplicationController
 
   def preview
     if printable && (@person.status == "registered")
-      @person.payment_role = payment_role(PersonDecorator.new(@person))
+      @person.payment_role = build_payment_role(@person)
       @person.save
 
       pdf = Wsjrdp2027::Export::Pdf::Registration.render(@person, true)
@@ -33,7 +33,7 @@ class Person::PrintController < ApplicationController
 
   def submit
     if printable && (@person.status == "registered")
-      @person.payment_role = payment_role(PersonDecorator.new(@person))
+      @person.payment_role = build_payment_role(@person)
       @person.save
 
       pdf = Wsjrdp2027::Export::Pdf::Registration.new_pdf(@person, false)

--- a/app/domain/wsjrdp_2027/export/pdf/registration.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration.rb
@@ -28,7 +28,7 @@ module Wsjrdp2027
           pdf.font "Montserrat"
           pdf.font_size 8
 
-          @person = PersonDecorator.new(person)
+          @person = person
 
           sections.each do |section|
             pstart = pdf.page_number

--- a/app/domain/wsjrdp_2027/export/pdf/registration/contract.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration/contract.rb
@@ -65,7 +65,7 @@ module Wsjrdp2027
         text "Den Medizinbogen, die Fotohinweise und das SEPA-Mandat im Anhang haben #{of_legal_age ? "habe ich" : "haben wir"} gesondert unterschrieben."
 
         pdf.move_down 3.mm
-        if payment_role(@person).start_with?("EarlyPayer")
+        if early_payer?(@person)
           text "Für die Zahlung des Teilnehmendenbeitrages wünsche ich Einmalzahlung im August 2025."
         else
           text "Für die Zahlung des Teilnehmendenbeitrages wünschen wir Ratenzahlung nach dem in den Reisebedingungen aufgeführten Ratenplan."

--- a/app/domain/wsjrdp_2027/export/pdf/registration/sepa.rb
+++ b/app/domain/wsjrdp_2027/export/pdf/registration/sepa.rb
@@ -33,7 +33,7 @@ module Wsjrdp2027
         text "Die Teilnahmebeitrag zum Jamboree werden mittels SEPA-Basislastschrift eingezogen:"
 
         pdf.move_down 3.mm
-        text "Ich ermächtige den Ring deutscher Pfadfinder*innenverbände e.V., die Zahlungen gemäß Zahlungsplan von meinem Konto mittels Lastschrift einzuziehen. Maßgeblich ist das von mir gewählte Zahlungsmodell (#{payment_role(@person).start_with?("EarlyPayer") ? "Einmalzahlung" : "Ratenzahlungen"}). Zugleich weise ich mein Kreditinstitut an, die vom Ring deutscher Pfadfinder*innenverbände e.V. auf mein Konto gezogenen Lastschriften einzulösen."
+        text "Ich ermächtige den Ring deutscher Pfadfinder*innenverbände e.V., die Zahlungen gemäß Zahlungsplan von meinem Konto mittels Lastschrift einzuziehen. Maßgeblich ist das von mir gewählte Zahlungsmodell (#{early_payer?(@person) ? "Einmalzahlung" : "Ratenzahlungen"}). Zugleich weise ich mein Kreditinstitut an, die vom Ring deutscher Pfadfinder*innenverbände e.V. auf mein Konto gezogenen Lastschriften einzulösen."
 
         pdf.move_down 3.mm
         text "Hinweis: Ich kann innerhalb von acht Wochen, beginnend mit dem Belastungsdatum, die Erstattung des belasteten Betrages verlangen."
@@ -54,7 +54,7 @@ module Wsjrdp2027
 
         pdf.move_down 3.mm
 
-        if payment_role(@person).start_with?("EarlyPayer")
+        if early_payer?(@person)
           text "Der Einzug des Gesamtbetrages von #{payment_value(@person)} € erfolgt am 5. August 2025."
         else
           text "Der Einzug erfolgt am 5. des jeweiligen Monats bzw. am darauffolgenden Werktag nach folgendem Ratenplan:"

--- a/app/helpers/contract_helper.rb
+++ b/app/helpers/contract_helper.rb
@@ -22,7 +22,7 @@ module ContractHelper
 
     # each person has a primary group which defines the price and role type
     def role_type(person)
-      roles = person.current_roles_grouped
+      roles = PersonDecorator.new(person).current_roles_grouped
       # If no role could be detected, fallback should be Youth Participant
       role = "Group::Unit::Member"
 
@@ -46,12 +46,12 @@ module ContractHelper
     end
 
     def person_payment_role_full_name(person)
-      role = payment_role(person)
+      role = build_payment_role(person)
       role_full_name(role.split("::", 2)[1])
     end
 
     # rubocop:disable Metrics/MethodLength
-    def payment_role(person)
+    def build_payment_role(person)
       role = role_type(person)
       payment_role_name = "RegularPayer"
 
@@ -74,30 +74,37 @@ module ContractHelper
 
     def cmt?(person)
       if person.payment_role.nil?
-        person.payment_role = payment_role(person)
+        person.payment_role = build_payment_role(person)
       end
       person.payment_role.ends_with?("Root::Member")
     end
 
     def ul?(person)
       if person.payment_role.nil?
-        person.payment_role = payment_role(person)
+        person.payment_role = build_payment_role(person)
       end
       person.payment_role.ends_with?("Unit::Leader")
     end
 
     def yp?(person)
       if person.payment_role.nil?
-        person.payment_role = payment_role(person)
+        person.payment_role = build_payment_role(person)
       end
       person.payment_role.ends_with?("Unit::Member")
     end
 
     def ist?(person)
       if person.payment_role.nil?
-        person.payment_role = payment_role(person)
+        person.payment_role = build_payment_role(person)
       end
       person.payment_role.ends_with?("Ist::Member")
+    end
+
+    def early_payer?(person)
+      if person.payment_role.nil?
+        person.payment_role = build_payment_role(person)
+      end
+      person.payment_role.start_with?("EarlyPayer")
     end
 
     def payment_array_by(person)

--- a/app/models/wsjrdp_2027/person.rb
+++ b/app/models/wsjrdp_2027/person.rb
@@ -7,7 +7,7 @@ module Wsjrdp2027::Person
 
   # This is just local to this module, it doesn't override anything when this module in included
   GENDERS = %w[m w d].freeze
-  BUDDY_ID_FORMAT = /^(?<tag>\w+-\w+)-(?<id>\d+)$/
+  BUDDY_ID_FORMAT = /^(?<tag>[a-zA-Z0-9_äöüÄÖÜß]+-[a-zA-Z0-9_äöüÄÖÜß]+)-(?<id>\d+)$/
 
   def self.included(base)
     # This hack is needed to make Person::GENDERS return the right value

--- a/config/locales/wsjrdp_2027.de.yml
+++ b/config/locales/wsjrdp_2027.de.yml
@@ -41,6 +41,13 @@ de:
     alert:
       only_pdf_allowed: Du kannst nur PDF Dateien hochladen.
 
+    errors:
+      models:
+        person:
+          buddy_self: "darf nicht deine eigene Buddy ID sein."
+          buddy_no_ul: "muss zu einer Person gehören, die Unit Leader ist."
+          buddy_no_yp: "muss zu einer Person gehören, die Youth Participant ist."
+
     attributes:
       person:
         nickname: Spitzname / Fahrtenname


### PR DESCRIPTION
We validate the entered buddy IDs like this:
- They have the right format
- They belong to a person in our system (id and spices match)
- It doesn't belong to oneself
- The buddy has the right role for the field

It was necessary to change the contract helper quite a bit to be able to use its functions in the Person model (check the commit message). This touches the core functionality. I tested it thoroughly and didn't see any issues so far. However, I open it as a draft for now. Please only merge merge it after testing it once again!