### PR TITLE
Prevent self inscription 

### DIFF
--- a/app/controllers/wsjrdp_2027/groups/self_inscription_controller.rb
+++ b/app/controllers/wsjrdp_2027/groups/self_inscription_controller.rb
@@ -1,0 +1,9 @@
+module Wsjrdp2027::Groups::SelfInscriptionController
+  extend ActiveSupport::Concern
+
+  included do
+    def create
+      render "show", status: :forbidden
+    end
+  end
+end

--- a/app/views/groups/self_inscription/_form.html.haml
+++ b/app/views/groups/self_inscription/_form.html.haml
@@ -1,0 +1,5 @@
+-# This form intentionally has not fields to prevent people from inscribing into multiple roles
+
+.row
+  .col
+    %p= raw(t('groups.self_inscription.impossible'))

--- a/config/locales/wsjrdp_2027.de.yml
+++ b/config/locales/wsjrdp_2027.de.yml
@@ -276,6 +276,8 @@ de:
           ul_to_young: "Als Unit Leader musst du zum Zeitpunkt deiner Registrierung (also Heute) mindestens 18 Jahre alt sein."
           ist_to_young: "Als IST musst du am Jamboree mindestens 18 Jahre alt sein. Also vor dem oder am 30.07.2009 geboren sein."
           cmt_to_young: "Als CMT musst du am Jamboree mindestens 18 Jahre alt sein. Also vor dem oder am 30.07.2009 geboren sein."
+    self_inscription:
+      impossible: 'Du bist bereits für das Deutsche Kontingent zum World Scout Jamboree 2027 registriert. Deswegen kannst du dich nicht für eine weitere Rolle registrieren. Wenn du eine andere Person registrieren möchtest, melde dich bitte zuerst ab. Wenn du deine Rolle ändern möchtest, kontaktiere uns bitte unter <a href="mailto:helpdesk@worldscoutjamboree.de">helpdesk@worldscoutjamboree.de</a>.'
 
   devise:
     mailer:

--- a/lib/hitobito_wsjrdp_2027/wagon.rb
+++ b/lib/hitobito_wsjrdp_2027/wagon.rb
@@ -27,6 +27,7 @@ module HitobitoWsjrdp2027
 
       # Controllers
       PeopleController.include Wsjrdp2027::PeopleController
+      Groups::SelfInscriptionController.include Wsjrdp2027::Groups::SelfInscriptionController
 
       # Helpers
       Sheet::Base.singleton_class.prepend Wsjrdp2027::Sheet::BaseClass


### PR DESCRIPTION
We don't want to allow an already registered user to self inscribe into another role. Show a message about it and prevent the self inscription from actually happening.