### PR TITLE
Fix VCP regions without sub-regions

### DIFF
--- a/config/rdp_groups.yml
+++ b/config/rdp_groups.yml
@@ -1931,6 +1931,7 @@ development:
         Matthias Claudius:
         Ulrich von Hutten:
       West:
+        Bei der Lutherbuche:
         Elbe:
         Graf Adolf von Schauenburg:
         Johannes Bugenhagen:
@@ -1999,30 +2000,31 @@ development:
         VCP Friedberg:
         Zecke:
     Mecklenburg-Vorpommern:
-      Biestower Braunbären:
-      Dargun + Stamm Levin/Zarnekow:
-      Die Luchse:
-      Die spähenden Falken:
-      Dierkower Erdmännchen:
-      Eric der Entdecker:
-      Groß Kleiner Elstern:
-      Lichtenhäger Wüstenfüchse:
-      Rövershäger Eichhörnchen:
-      Scouven Güstrow:
-      Seeadler:
-      St. Georg:
-      St. Jakobus Kavelstorf:
-      Stamm Heinrich der Löwe:
-      Stamm Luzin:
-      Stamm Rügen:
-      Stamm Vineta:
-      Stamm Waldkauz:
-      Stamm Weitenhagen:
-      Turmfalken Remplin:
-      Vellahner Pfauen:
-      Wanderfalken:
-      Warnemünder Wölfe:
-      Wittenburg:
+      Keine Bezirksebene:
+        Biestower Braunbären:
+        Dargun + Stamm Levin/Zarnekow:
+        Die Luchse:
+        Die spähenden Falken:
+        Dierkower Erdmännchen:
+        Eric der Entdecker:
+        Groß Kleiner Elstern:
+        Lichtenhäger Wüstenfüchse:
+        Rövershäger Eichhörnchen:
+        Scouven Güstrow:
+        Seeadler:
+        St. Georg:
+        St. Jakobus Kavelstorf:
+        Stamm Heinrich der Löwe:
+        Stamm Luzin:
+        Stamm Rügen:
+        Stamm Vineta:
+        Stamm Waldkauz:
+        Stamm Weitenhagen:
+        Turmfalken Remplin:
+        Vellahner Pfauen:
+        Wanderfalken:
+        Warnemünder Wölfe:
+        Wittenburg:
     Mitteldeutschland:
       Sachsen-Anhalt:
         Cracau Citz:
@@ -2248,98 +2250,101 @@ development:
         Siedlung Richard Löwenherz:
         Stamm Daun under:
     Sachsen:
-      Bad Lausick:
-      Drachentiere:
-      Einsiedel Syhra:
-      Heinrich Zille:
-      Heinrich von Berlepsch:
-      Johannes der Täufer:
-      Karl May:
-      King Jesus friends:
-      Neuostra - Heiliger Born:
-      Pilgrim:
-      Pingtrosse:
-      Rotfuchs:
-      Salomo:
-      Schildbürger:
-      Schleiereulen Radeberg:
-      Schwarzkiefer:
-      St. Jakobus:
-      Stamm Eisvogel:
-      Stamm Gebirgsfalken:
-      Stamm Morgenstern:
-      Stamm Räuberhauptmann Karasek:
-      Stamm Steinadler:
-      Stamm de Auenwaldräuber:
-      Sturmkrähen - Siedlung Zittau:
-      Trachenschlucht:
-      Turmfalken:
-      VCP Limbach/Vogtland:
-      VCP Moritzburg:
-      VCP Oberlungwitz:
-      Wenceslai:
+      Keine Bezirksebene:
+        Bad Lausick:
+        Drachentiere:
+        Einsiedel Syhra:
+        Heinrich Zille:
+        Heinrich von Berlepsch:
+        Johannes der Täufer:
+        Karl May:
+        King Jesus friends:
+        Neuostra - Heiliger Born:
+        Pilgrim:
+        Pingtrosse:
+        Rotfuchs:
+        Salomo:
+        Schildbürger:
+        Schleiereulen Radeberg:
+        Schwarzkiefer:
+        St. Jakobus:
+        Stamm Eisvogel:
+        Stamm Gebirgsfalken:
+        Stamm Morgenstern:
+        Stamm Räuberhauptmann Karasek:
+        Stamm Steinadler:
+        Stamm de Auenwaldräuber:
+        Sturmkrähen - Siedlung Zittau:
+        Trachenschlucht:
+        Turmfalken:
+        VCP Limbach/Vogtland:
+        VCP Moritzburg:
+        VCP Oberlungwitz:
+        Wenceslai:
     Schleswig-Holstein:
-      11 oben:
-      Alderaan:
-      Ansgar:
-      Aspasia:
-      Aver Liekers:
-      Cartoons:
-      Cassiopeia:
-      Die Falken:
-      Dunedain:
-      Kopernikus:
-      Likedeeler:
-      Markus Löwen:
-      Martje Flor:
-      Mori:
-      Nimrod:
-      Normannen:
-      Ritter von Barmstede:
-      Siedlung Lüneborg:
-      St. Georg:
-      St. Michael:
-      Stamm Briganten:
-      Stamm Gosharde:
-      Stamm Heide:
-      Steve Biko:
-      Swentana:
-      Vicelin:
-      Wikinger:
-      Wisent:
-      nordFlues:
-      von Acken:
+      Keine Bezirksebene:
+        11 oben:
+        Alderaan:
+        Ansgar:
+        Aspasia:
+        Aver Liekers:
+        Cartoons:
+        Cassiopeia:
+        Die Falken:
+        Dunedain:
+        Kopernikus:
+        Likedeeler:
+        Markus Löwen:
+        Martje Flor:
+        Mori:
+        Nimrod:
+        Normannen:
+        Ritter von Barmstede:
+        Siedlung Lüneborg:
+        St. Georg:
+        St. Michael:
+        Stamm Briganten:
+        Stamm Gosharde:
+        Stamm Heide:
+        Steve Biko:
+        Swentana:
+        Vicelin:
+        Wikinger:
+        Wisent:
+        nordFlues:
+        von Acken:
     Westfalen:
-      Abraham Jacobi:
-      Albert Schweitzer:
-      Arbalo:
-      Asgard:
-      Bonhoeffer:
-      Cherusker:
-      Hagen-Emst:
-      Junker Jörg:
-      Nodan:
-      Pankratius:
-      Paul Gerhardt:
-      Schwelm:
-      Stamm Bega:
-      Stamm David:
-      Stamm Elijah:
-      Stamm Hucriti:
-      Stamm Humbold:
-      Stamm Johannes:
-      Stamm Schmallenberg:
-      Stamm Thingslinde:
-      Ulrich von Hutten:
-      VCP Bochum:
-      VCP Bochum-Melanchthon:
-      VCP Hattingen:
-      VCP Löhne:
-      VCP Marl-Hamm:
-      VCP Wattenscheid:
-      Wildpferde:
-      Wittekind:
-      Zone Bethel:
+      Keine Bezirksebene:
+        Abraham Jacobi:
+        Albert Schweitzer:
+        Arbalo:
+        Asgard:
+        Bonhoeffer:
+        Cherusker:
+        Hagen-Emst:
+        Junker Jörg:
+        Nodan:
+        Pankratius:
+        Paul Gerhardt:
+        Schwelm:
+        Stamm Bega:
+        Stamm David:
+        Stamm Elijah:
+        Stamm Hucriti:
+        Stamm Humbold:
+        Stamm Johannes:
+        Stamm Schmallenberg:
+        Stamm Thingslinde:
+        Ulrich von Hutten:
+        VCP Bochum:
+        VCP Bochum-Melanchthon:
+        VCP Hattingen:
+        VCP Löhne:
+        VCP Marl-Hamm:
+        VCP Wattenscheid:
+        Wildpferde:
+        Wittekind:
+        Zone Bethel:
     Württemberg:
       CVJM-Esslingen:
         CVJM-Esslingen:
@@ -4348,6 +4353,7 @@ production:
         Matthias Claudius:
         Ulrich von Hutten:
       West:
+        Bei der Lutherbuche:
         Elbe:
         Graf Adolf von Schauenburg:
         Johannes Bugenhagen:
@@ -4416,30 +4422,31 @@ production:
         VCP Friedberg:
         Zecke:
     Mecklenburg-Vorpommern:
-      Biestower Braunbären:
-      Dargun + Stamm Levin/Zarnekow:
-      Die Luchse:
-      Die spähenden Falken:
-      Dierkower Erdmännchen:
-      Eric der Entdecker:
-      Groß Kleiner Elstern:
-      Lichtenhäger Wüstenfüchse:
-      Rövershäger Eichhörnchen:
-      Scouven Güstrow:
-      Seeadler:
-      St. Georg:
-      St. Jakobus Kavelstorf:
-      Stamm Heinrich der Löwe:
-      Stamm Luzin:
-      Stamm Rügen:
-      Stamm Vineta:
-      Stamm Waldkauz:
-      Stamm Weitenhagen:
-      Turmfalken Remplin:
-      Vellahner Pfauen:
-      Wanderfalken:
-      Warnemünder Wölfe:
-      Wittenburg:
+      Keine Bezirksebene:
+        Biestower Braunbären:
+        Dargun + Stamm Levin/Zarnekow:
+        Die Luchse:
+        Die spähenden Falken:
+        Dierkower Erdmännchen:
+        Eric der Entdecker:
+        Groß Kleiner Elstern:
+        Lichtenhäger Wüstenfüchse:
+        Rövershäger Eichhörnchen:
+        Scouven Güstrow:
+        Seeadler:
+        St. Georg:
+        St. Jakobus Kavelstorf:
+        Stamm Heinrich der Löwe:
+        Stamm Luzin:
+        Stamm Rügen:
+        Stamm Vineta:
+        Stamm Waldkauz:
+        Stamm Weitenhagen:
+        Turmfalken Remplin:
+        Vellahner Pfauen:
+        Wanderfalken:
+        Warnemünder Wölfe:
+        Wittenburg:
     Mitteldeutschland:
       Sachsen-Anhalt:
         Cracau Citz:
@@ -4665,98 +4672,101 @@ production:
         Siedlung Richard Löwenherz:
         Stamm Daun under:
     Sachsen:
-      Bad Lausick:
-      Drachentiere:
-      Einsiedel Syhra:
-      Heinrich Zille:
-      Heinrich von Berlepsch:
-      Johannes der Täufer:
-      Karl May:
-      King Jesus friends:
-      Neuostra - Heiliger Born:
-      Pilgrim:
-      Pingtrosse:
-      Rotfuchs:
-      Salomo:
-      Schildbürger:
-      Schleiereulen Radeberg:
-      Schwarzkiefer:
-      St. Jakobus:
-      Stamm Eisvogel:
-      Stamm Gebirgsfalken:
-      Stamm Morgenstern:
-      Stamm Räuberhauptmann Karasek:
-      Stamm Steinadler:
-      Stamm de Auenwaldräuber:
-      Sturmkrähen - Siedlung Zittau:
-      Trachenschlucht:
-      Turmfalken:
-      VCP Limbach/Vogtland:
-      VCP Moritzburg:
-      VCP Oberlungwitz:
-      Wenceslai:
+      Keine Bezirksebene:
+        Bad Lausick:
+        Drachentiere:
+        Einsiedel Syhra:
+        Heinrich Zille:
+        Heinrich von Berlepsch:
+        Johannes der Täufer:
+        Karl May:
+        King Jesus friends:
+        Neuostra - Heiliger Born:
+        Pilgrim:
+        Pingtrosse:
+        Rotfuchs:
+        Salomo:
+        Schildbürger:
+        Schleiereulen Radeberg:
+        Schwarzkiefer:
+        St. Jakobus:
+        Stamm Eisvogel:
+        Stamm Gebirgsfalken:
+        Stamm Morgenstern:
+        Stamm Räuberhauptmann Karasek:
+        Stamm Steinadler:
+        Stamm de Auenwaldräuber:
+        Sturmkrähen - Siedlung Zittau:
+        Trachenschlucht:
+        Turmfalken:
+        VCP Limbach/Vogtland:
+        VCP Moritzburg:
+        VCP Oberlungwitz:
+        Wenceslai:
     Schleswig-Holstein:
-      11 oben:
-      Alderaan:
-      Ansgar:
-      Aspasia:
-      Aver Liekers:
-      Cartoons:
-      Cassiopeia:
-      Die Falken:
-      Dunedain:
-      Kopernikus:
-      Likedeeler:
-      Markus Löwen:
-      Martje Flor:
-      Mori:
-      Nimrod:
-      Normannen:
-      Ritter von Barmstede:
-      Siedlung Lüneborg:
-      St. Georg:
-      St. Michael:
-      Stamm Briganten:
-      Stamm Gosharde:
-      Stamm Heide:
-      Steve Biko:
-      Swentana:
-      Vicelin:
-      Wikinger:
-      Wisent:
-      nordFlues:
-      von Acken:
+      Keine Bezirksebene:
+        11 oben:
+        Alderaan:
+        Ansgar:
+        Aspasia:
+        Aver Liekers:
+        Cartoons:
+        Cassiopeia:
+        Die Falken:
+        Dunedain:
+        Kopernikus:
+        Likedeeler:
+        Markus Löwen:
+        Martje Flor:
+        Mori:
+        Nimrod:
+        Normannen:
+        Ritter von Barmstede:
+        Siedlung Lüneborg:
+        St. Georg:
+        St. Michael:
+        Stamm Briganten:
+        Stamm Gosharde:
+        Stamm Heide:
+        Steve Biko:
+        Swentana:
+        Vicelin:
+        Wikinger:
+        Wisent:
+        nordFlues:
+        von Acken:
     Westfalen:
-      Abraham Jacobi:
-      Albert Schweitzer:
-      Arbalo:
-      Asgard:
-      Bonhoeffer:
-      Cherusker:
-      Hagen-Emst:
-      Junker Jörg:
-      Nodan:
-      Pankratius:
-      Paul Gerhardt:
-      Schwelm:
-      Stamm Bega:
-      Stamm David:
-      Stamm Elijah:
-      Stamm Hucriti:
-      Stamm Humbold:
-      Stamm Johannes:
-      Stamm Schmallenberg:
-      Stamm Thingslinde:
-      Ulrich von Hutten:
-      VCP Bochum:
-      VCP Bochum-Melanchthon:
-      VCP Hattingen:
-      VCP Löhne:
-      VCP Marl-Hamm:
-      VCP Wattenscheid:
-      Wildpferde:
-      Wittekind:
-      Zone Bethel:
+      Keine Bezirksebene:
+        Abraham Jacobi:
+        Albert Schweitzer:
+        Arbalo:
+        Asgard:
+        Bonhoeffer:
+        Cherusker:
+        Hagen-Emst:
+        Junker Jörg:
+        Nodan:
+        Pankratius:
+        Paul Gerhardt:
+        Schwelm:
+        Stamm Bega:
+        Stamm David:
+        Stamm Elijah:
+        Stamm Hucriti:
+        Stamm Humbold:
+        Stamm Johannes:
+        Stamm Schmallenberg:
+        Stamm Thingslinde:
+        Ulrich von Hutten:
+        VCP Bochum:
+        VCP Bochum-Melanchthon:
+        VCP Hattingen:
+        VCP Löhne:
+        VCP Marl-Hamm:
+        VCP Wattenscheid:
+        Wildpferde:
+        Wittekind:
+        Zone Bethel:
     Württemberg:
       CVJM-Esslingen:
         CVJM-Esslingen:


### PR DESCRIPTION
* Add: a pseudo sub-region "Keine Bezirksebene" for VCP regions without sub-regions (Mecklenburg-Vorpommern, Sachsen, Schleswig-Holstein, Westfalen)
* Add VCP Hamburg Stamm "Bei der Lutherbuche"

Adding pseudo sub-regions helps to calculate statistics about groups.