### PR TITLE
Fix ruby / Debian to bookworm

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -8,6 +8,7 @@ ARG RUBY_VERSION="3.2"
 ARG BUNDLER_VERSION="2.5.22"
 ARG NODEJS_VERSION="16"
 ARG YARN_VERSION="1.22.19"
+ARG DEBIAN_VERSION="bookworm"
 
 # Packages
 ARG BUILD_PACKAGES="nodejs git build-essential libpq-dev libvips42"
@@ -89,7 +90,7 @@ ARG TZ="Europe/Zurich"
 #          Build Stage          #
 #################################
 
-FROM ruby:${RUBY_VERSION} AS build
+FROM ruby:${RUBY_VERSION}-${DEBIAN_VERSION} AS build
 
 # arguments for steps
 ARG HOME
@@ -172,7 +173,7 @@ RUN rm -rf vendor/cache/ .git spec/ node_modules/ .npm/
 #################################
 
 # This image will be replaced by Openshift
-FROM ruby:${RUBY_VERSION}-slim AS app
+FROM ruby:${RUBY_VERSION}-slim-${DEBIAN_VERSION} AS app
 
 # arguments for steps
 ARG RUN_PACKAGES


### PR DESCRIPTION
Ruby updated to trixie and this broken our container images.
Fix to Debian Bookworm to get running container images similar to hitobito original deployment. 