### PR TITLE
Remove `:cluster_code` and `:wsj_role` from public Person attributes

### DIFF
--- a/app/helpers/wsjrdp_2027/people_helper.rb
+++ b/app/helpers/wsjrdp_2027/people_helper.rb
@@ -58,7 +58,7 @@ module Wsjrdp2027::PeopleHelper
     if (role = person.wsj_role).present?
       role
     else
-      content_tag(:span, "#{person.short_payment_role} (abgeleitet von der WSJRDP Rolle)", class: "muted fw-light")
+      person.short_payment_role
     end
   end
 

--- a/app/models/wsjrdp_2027/person.rb
+++ b/app/models/wsjrdp_2027/person.rb
@@ -25,8 +25,6 @@ module Wsjrdp2027::Person
   # Note: Do not include store_accessor attributes in PUBLIC_ATTRS
   WSJRDP_PUBLIC_ATTRS = WSJRDP_FILTER_ATTRS + [
     :additional_info,
-    :cluster_code,
-    :wsj_role,
     :zero_padded_id
   ].freeze
 
@@ -40,6 +38,12 @@ module Wsjrdp2027::Person
     :wsjrdp_email_updated_at,
     :zero_padded_id  # note: Also in WSJRDP_PUBLIC_ATTRS
   ].freeze
+
+  # Added to INTERNAL_ATTRS and used_attributes, but not skipped from paper trail
+  WSJRDP_INTERNAL_ATTRS_WITH_PAPER_TRAIL = [
+    :company_name,
+    :company
+  ]
 
   WSJRDP_SEARCHABLE_ATTRS = [
     :id,
@@ -71,10 +75,13 @@ module Wsjrdp2027::Person
     # Be careful to modify existing variables instead of re-assigning
     # them to avoid Ruby warnings.
     Person::FILTER_ATTRS.concat(WSJRDP_FILTER_ATTRS)
+    Person::FILTER_ATTRS.delete :company_name
     Person::PUBLIC_ATTRS.concat(WSJRDP_PUBLIC_ATTRS)
     Person::INTERNAL_ATTRS.concat(WSJRDP_INTERNAL_ATTRS)
+    Person::INTERNAL_ATTRS.concat(WSJRDP_INTERNAL_ATTRS_WITH_PAPER_TRAIL)
     Person.used_attributes.concat(WSJRDP_PUBLIC_ATTRS)
     Person.used_attributes.concat(WSJRDP_INTERNAL_ATTRS)
+    Person.used_attributes.concat(WSJRDP_INTERNAL_ATTRS_WITH_PAPER_TRAIL)
     Person.used_attributes.uniq!
     # Searching for birthdays interferes too much with searching for a
     # persons id, so we remove :birthday from SEARCHABLE_ATTRS.

--- a/app/views/person/status/show.html.haml
+++ b/app/views/person/status/show.html.haml
@@ -17,7 +17,13 @@
     - extra_render_attrs << :planned_custom_installments_display
     - extra_render_attrs << :planned_custom_installments_comment
   = render_attrs_list do
-    = labeled_attrs(@person, :birthday, :status_log_display, :print_at, :contract_upload_at, :complete_document_upload_at, :payment_role, :wsj_role)
+    = labeled_attrs(@person, :birthday, :status_log_display, :print_at, :contract_upload_at, :complete_document_upload_at, :payment_role)
+    - if @person.wsj_role.present?
+      = labeled_attr(@person, :wsj_role)
+    - else
+      = labeled_attr_with_help(@person, :wsj_role) do
+        %span.muted
+          (nich gesetzt, abgeleitet von der WSJRDP Rolle)
     - if @person.ist?
       = labeled_attr(@person, :is_preallocated_ist)
     = labeled_attr(@person, :unit_code)


### PR DESCRIPTION
Other changes:
* Mark `:company_name` and `:company` as internal without skipping
  them from paper trails.
* Tweak formatting of `:wsj_role`.

Problem: When `:wsj_role` is public, then the formatting method `format_person_wsj_role` might need to access `:payment_role` (if `:wsj_role` is `nil`). As `:payment_role` is not public, this then leads to an error.

Solution: Remove `:wsj_role` from the public attrs. While cleaning up, also remove `:cluster_code` and hide `:company` and `:company_name` from column selection and from filtering.

Fixes https://helpdesk.worldscoutjamboree.de/browse/HELP-1721