### PR TITLE
Add `typst` and `rison`

### DIFF
--- a/hitobito_wsjrdp_2027.gemspec
+++ b/hitobito_wsjrdp_2027.gemspec
@@ -18,6 +18,12 @@ Gem::Specification.new do |s|
 
   s.add_dependency "iban-tools", "~> 1.1"
   s.add_dependency "geocoder", "~> 1.3", ">= 1.3.7"
+  s.add_dependency "rison", "~> 2.1"
+  s.add_dependency "typst", "~> 0.15.1", ">= 0.15.1.5"
+  # typst requires rubyzip ~> 3.2. With rubyzip 3.x, caxlsx writes Zip64 archives
+  # by default, which Google Sheets refuses to import. caxlsx 4.4.1 disables Zip64
+  # by default again (https://github.com/caxlsx/caxlsx/pull/482), so floor it there.
+  s.add_dependency "caxlsx", ">= 4.4.1"
 
   s.add_runtime_dependency "chartkick"
   s.add_runtime_dependency "chart-js-rails"


### PR DESCRIPTION
* Add `typst` to have a powerful tool for fast PDF generation used in some offline Python scripts in `wsjrdp_scripts`. Having this in available in Hitobito will make it easier to port the functionality of some scripts into Hitobito.

* Add `rison` for future query-encoding of filter params for financial pages.

Note: Upstream Hitobito still uses "caxlsx", "< 4.3.0", but introducing `typst` triggers a chain of updates, resulting in the usage of `caxlsx` 4.5.0. This should be fine by now as the problems listed in https://github.com/caxlsx/caxlsx/issues/481 (broken xlsx files when using `rubyzip` > 3) should be fixed since version 4.4.1 of `caxlsx`.

Gem updates triggered by `typst` and `rison`:

| Gem     | Before | After     | Why                                          |
|---------|--------|-----------|----------------------------------------------|
| rison   | —      | 2.1.0     | added directly                               |
| typst   | —      | 0.15.1.5  | added directly                               |
| parslet | —      | 1.8.2     | runtime dep of rison                         |
| rb_sys  | —      | 0.9.128   | dep of typst (lock only; precompiled skips)  |
| rubyzip | 2.3.2  | 3.5.0     | typst requires rubyzip ~> 3.2                |
| caxlsx  | 4.1.0  | 4.5.0     | bumped to be compatible with rubyzip 3.x     |
