### PR TITLE
Add AccountingEntry.excluded_from_fee_reconciliation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@ Gemfile.lock
 # uploaded pdf files
 /private/ 
 
+# ignore local dev overrides:
+# for dev login
+config/initializers/local_dev_login.rb
+# different file watching on macOS
+config/initializers/local_dev_file_watcher.rb
+
 # reports
 spec/coverage
 spec/reports

--- a/app/controllers/fin/accounting_entries_controller.rb
+++ b/app/controllers/fin/accounting_entries_controller.rb
@@ -119,7 +119,8 @@ class Fin::AccountingEntriesController < Fin::FinController
           :endtoend_id,
           :dbtr_name, :dbtr_iban, :dbtr_bic, :dbtr_address,
           :cdtr_name, :cdtr_iban, :cdtr_bic, :cdtr_address,
-          :mandate_id, :mandate_date, :debit_sequence_type
+          :mandate_id, :mandate_date, :debit_sequence_type,
+          :excluded_from_fee_reconciliation
         ]
       end
     else

--- a/app/helpers/wsjrdp_jsonb_helper.rb
+++ b/app/helpers/wsjrdp_jsonb_helper.rb
@@ -12,7 +12,12 @@ module WsjrdpJsonbHelper
   include ActiveRecord::Store
 
   module ClassMethods
-    def jsonb_accessor(store_attribute, key, prefix: nil, suffix: nil, strip: false, delete_on_blank: true, created_at_key: nil, updated_at_key: nil)
+    # cast: :boolean -- values are cast with ActiveModel::Type::Boolean before
+    # the blank check, so form params ("1"/"0"/"true"/"false") behave like real
+    # booleans. Combined with delete_on_blank (false.blank? is true), clearing
+    # a boolean flag REMOVES the key from the JSONB: absent == false == the
+    # default. Also defines a `<key>?` predicate.
+    def jsonb_accessor(store_attribute, key, prefix: nil, suffix: nil, strip: false, delete_on_blank: true, created_at_key: nil, updated_at_key: nil, cast: nil)
       accessor_prefix =
         case prefix
         when String, Symbol
@@ -36,6 +41,7 @@ module WsjrdpJsonbHelper
       store_accessor_module = instance_method(:"#{accessor_key}=").owner
       store_accessor_module.module_eval do
         define_method(:"#{accessor_key}=") do |value|
+          value = ActiveModel::Type::Boolean.new.cast(value) if cast == :boolean
           value = value&.strip if strip
           if delete_on_blank && value.blank?
             send(store_attribute)&.delete(accessor_key)
@@ -52,6 +58,11 @@ module WsjrdpJsonbHelper
               end
             end
             write_store_attribute(store_attribute, key, value)
+          end
+        end
+        if cast == :boolean
+          define_method(:"#{accessor_key}?") do
+            !!read_store_attribute(store_attribute, key)
           end
         end
       end

--- a/app/models/accounting_entry.rb
+++ b/app/models/accounting_entry.rb
@@ -3,6 +3,18 @@
 class AccountingEntry < ActiveRecord::Base
   include ActionView::Helpers::TextHelper
   include WsjrdpNumberHelper
+  include WsjrdpJsonbHelper
+
+  # true = this entry does NOT take part in the participant-fee reconciliation
+  # Key absent or false = it takes part (default)
+  jsonb_accessor :additional_info, :excluded_from_fee_reconciliation, cast: :boolean
+
+  scope :excluded_from_fee_reconciliation, -> {
+    where("(accounting_entries.additional_info ->> 'excluded_from_fee_reconciliation')::boolean IS TRUE")
+  }
+  scope :fee_reconciliation_relevant, -> {
+    where.not("(accounting_entries.additional_info ->> 'excluded_from_fee_reconciliation')::boolean IS TRUE")
+  }
 
   belongs_to :subject, polymorphic: true, optional: true
   belongs_to :author, polymorphic: true

--- a/app/views/fin/accounting_entries/_accounting_entry_form.html.haml
+++ b/app/views/fin/accounting_entries/_accounting_entry_form.html.haml
@@ -21,6 +21,8 @@
   %div.border-top.py-2
   = f.labeled_input_field :value_date, help_inline: 'Nur falls abweichend vom aktuellen Datum'
   = f.labeled_input_field :endtoend_id, help_inline: 'SEPA Ende-zu-Ende-Referenz'
+  = f.labeled_boolean_field :excluded_from_fee_reconciliation,
+    caption: 'Diese Buchung nimmt nicht an der Abstimmung der TN-Beiträge teil'
   %div.border-top.py-2
   = f.labeled_input_fields :dbtr_name, :dbtr_iban, :dbtr_bic, :dbtr_address
   %div.border-top.py-2

--- a/app/views/person/accounting_entries/show.html.haml
+++ b/app/views/person/accounting_entries/show.html.haml
@@ -37,6 +37,9 @@
       = input_or_render_attrs(f, :comment, help_inline: 'Nur sichtbar für Personen mit Buchhaltungs-Rechten')
       %div.border-top.py-2
       = input_or_render_attrs(f, :value_date, :debit_sequence_type, :endtoend_id)
+      - if permitted_attrs.include?(:excluded_from_fee_reconciliation)
+        = f.labeled_boolean_field :excluded_from_fee_reconciliation,
+          caption: 'Diese Buchung nimmt nicht an der Abstimmung der TN-Beiträge teil'
       %div.border-top.py-2
       = input_or_render_attrs(f, :dbtr_name, :dbtr_iban, :dbtr_bic, :dbtr_address)
       = input_or_render_attrs(f, :mandate_id, :mandate_date)

--- a/config/locales/wsjrdp_2027.de.yml
+++ b/config/locales/wsjrdp_2027.de.yml
@@ -181,6 +181,7 @@ de:
         updated_at: Geändert
         subject: Person
         subject_id: Person
+        excluded_from_fee_reconciliation: Von der Beitrags-Abstimmung ausgenommen
         amount_eur: Betrag in Euro
         amount_eur_display: Betrag in Euro
         pre_notified_amount_eur: Vorab informierter Betrag in Euro


### PR DESCRIPTION
In rare cases, some accounting entries do not need to be reconciliated with DATEV bookings. The PR introduces a new boolean flag on the `AccountingEntry` model for this purpose. It is stored in the `additional_info` JSONB column. This way we don't need a database migration and do not have to add a column which is only very rarely used.

Unrelated: Add some local dev-only overrides to `.gitignore` to ensure they will never end up in staging or production.
