### PR TITLE
Write xlsx exports as classic Zip (version 2.0), not as Zip64 (version 4.5)

### DIFF
--- a/config/initializers/zip64.rb
+++ b/config/initializers/zip64.rb
@@ -1,0 +1,11 @@
+require "zip"
+
+# rubyzip 3.x defaults Zip.write_zip64_support to true. That makes every zip
+# entry -- including the internal parts of a .xlsx built by caxlsx -- declare
+# "version needed to extract = 4.5" (Zip64), even for small files that use no
+# Zip64 features at all. Strict consumers such as Google Sheets then refuse the
+# file. caxlsx >= 4.4.1 (https://github.com/caxlsx/caxlsx/pull/482) means to
+# disable this by default, but that does not take effect with rubyzip 3.5.0.
+#
+# Turn Zip64 off explicitly so exports are written as the classic 2.0 spec.
+Zip.write_zip64_support = false


### PR DESCRIPTION
Problem: Adding the `typst` gem pulled in `rubyzip` 3.x, whose default `Zip.write_zip64_support = true` makes every zip entry (including the internal parts of a `.xlsx` generated by `caxlsx`) declare "version
needed to extract = 4.5", even for small files that use no Zip64 features. Running `zipdetails` on a people export confirmed all entries stamped 4.5 with no actual Zip64 records present. Strict readers such as Google Sheets reject such files. `caxlsx >= 4.4.1` (see caxlsx/caxlsx#482) meant to disable this by default, but that does not seem to take effect as intended with `rubyzip` 3.5.0.

Solution: Disable Zip64 explicitly in a wagon initializer so `caxlsx` (`rubyzip`) write entries as version 2.0 again. A re-check showed: every entry drops back to '2.0' and still no actual Zip64 structures are used.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
