### PR TITLE
Add URL query encoding helpers (RelaxedUrlQuery, wsjrdpRelaxedQuery)

### DIFF
--- a/.github/workflows/wagon-tests.yml
+++ b/.github/workflows/wagon-tests.yml
@@ -59,6 +59,33 @@ jobs:
         run: |
           bundle exec rake app:rubocop
 
+  # Client-side helper tests (doc/url_encoding.md §6). No core, no bundle, no DB:
+  # the suites use only node's built-in test runner, so this job is seconds long.
+  # Without it the JS half of the mandatory URL-encoding helpers would rest on
+  # developer discipline alone, while its Ruby twin runs in wagon_specs.
+  javascript_specs:
+    name: javascript specs
+    runs-on: "ubuntu-22.04"
+    steps:
+      - name: Check out ${{ inputs.wagon_repository }}
+        uses: actions/checkout@v4
+        with:
+          path: ${{ inputs.wagon_repository }}
+          fetch-depth: 1
+
+      # Pinned rather than relying on the runner image default: `node --test`
+      # only expands glob arguments itself on recent versions, and the image
+      # default may lag behind or change.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      # Quote the glob so node expands it, not the shell. A bare directory
+      # argument does NOT work (it is resolved as a module path).
+      - name: Run node test suites
+        working-directory: ${{ inputs.wagon_repository }}
+        run: node --test "spec/javascripts/**/*.test.mjs"
+
   wagon_seeds:
     name: seeds
     runs-on: "ubuntu-22.04"

--- a/app/models/relaxed_url_query.rb
+++ b/app/models/relaxed_url_query.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026 German Contingent for the World Scout Jamboree 2027.
+#
+#  This file is part of hitobito_wsjrdp_2027 and licensed under the
+#  Affero General Public License version 3 or later. See the COPYING
+#  file at the top-level directory or at
+#  https://github.com/smeky42/hitobito_wsjrdp_2027
+
+# Builds URL query strings in which the characters "," and "~" stay LITERAL
+# instead of percent-encoded ("?sort=bez,nr~" rather than "?sort=bez%2Cnr%7E").
+# Both are safe unencoded in a query per RFC 3986 ("," is a sub-delim Rack never
+# splits a value on, "~" is unreserved); see doc/url_encoding.md.
+#
+# SECURITY -- the encapsulation rule (doc/url_encoding.md §6): the %XX -> literal
+# "relax" replacement is only safe on the IMMEDIATE output of a proper
+# percent-encoder, where a raw "%" cannot occur (every "%" starts a %XX escape,
+# so "%2C" can only ever be an encoded comma). This module therefore exposes
+# ONLY hash-in/query-string-out -- encode and relax happen inside one method,
+# and no public API accepts a pre-built string. Do not add one, and do not
+# scatter standalone `.gsub("%2C", ",")` calls elsewhere; widen RELAXATIONS
+# only for separator-free characters and only together with new spec coverage
+# (spec/models/relaxed_url_query_spec.rb).
+module RelaxedUrlQuery
+  # %XX escape => literal character. Only characters that no parser in our stack
+  # treats as a separator may ever be listed here (NEVER "&" %26, "=" %3D,
+  # "+" %2B, "#" %23, "%" %25, ";" %3B while unverified). Keys must be the
+  # UPPERCASE hex form, which is what ERB/CGI/to_query emit.
+  RELAXATIONS = {
+    "%2C" => ",",
+    "%7E" => "~"
+  }.freeze
+
+  RELAXATION_PATTERN = Regexp.union(RELAXATIONS.keys).freeze
+
+  # Private so the pieces cannot be reassembled into the forbidden raw-string
+  # relax from outside (`str.gsub(RelaxedUrlQuery::RELAXATION_PATTERN, ...)`).
+  # The spec reaches them via const_get, which bypasses this deliberately.
+  private_constant :RELAXATIONS, :RELAXATION_PATTERN
+
+  module_function
+
+  # params (Hash, may be nested / contain arrays) -> query string with the
+  # RELAXATIONS applied, e.g. {sort: "bez,nr~"} -> "sort=bez,nr~". Returns "" for
+  # blank params. The only public entry point: encoding (Rails Hash#to_query,
+  # which percent-encodes every "%" as %25) and relaxing are one step, so the
+  # relax can never touch a string containing a raw "%".
+  #
+  # Only a Hash is accepted -- explicitly, not by accident. A String would also
+  # raise (String#to_query needs a key), but relying on that would make the core
+  # safety property an implementation detail of Rails; anything already encoded
+  # must never reach the relax step. Mirrors the JS helper's TypeError.
+  def to_query(params)
+    unless params.is_a?(Hash)
+      raise TypeError, "RelaxedUrlQuery.to_query expects a Hash, got #{params.class}"
+    end
+    params.to_query.gsub(RELAXATION_PATTERN, RELAXATIONS)
+  end
+end

--- a/app/views/shared/_relaxed_query_js.html.haml
+++ b/app/views/shared/_relaxed_query_js.html.haml
@@ -1,0 +1,59 @@
+-#  Copyright (c) 2026 German Contingent for the World Scout Jamboree 2027.
+-#
+-#  This file is part of hitobito_wsjrdp_2027 and licensed under the
+-#  Affero General Public License version 3 or later.
+-#  See the COPYING file at the top-level directory or at
+-#  https://github.com/smeky42/hitobito_wsjrdp_2027
+-#
+-#  window.wsjrdpRelaxedQuery -- build URL query strings with "," and "~" LITERAL
+-#  instead of %2C/%7E (both are RFC 3986-safe in a query; see
+-#  doc/url_encoding.md). SECURITY (doc/url_encoding.md §6): encode + relax are
+-#  encapsulated in one function; the API only accepts STRUCTURED input
+-#  (URLSearchParams / FormData / URL) and throws on strings, so the %XX->literal
+-#  replacement can never run on a string containing a raw "%". Tested by
+-#  spec/javascripts/relaxed_query.test.mjs, which extracts the code between the
+-#  marker comments below -- keep the markers when editing.
+-#
+-#  Render this partial before any :javascript block that uses the helper; the
+-#  ivar guard emits it once per request, the window guard once per page.
+- return if @wsjrdp_relaxed_query_js_emitted
+- @wsjrdp_relaxed_query_js_emitted = true
+:javascript
+  // wsjrdp-relaxed-query-begin
+  (function () {
+    if (window.wsjrdpRelaxedQuery) return;
+    // URLSearchParams | FormData -> query string with "," and "~" literal.
+    // Serialisation (URLSearchParams.toString, which encodes every raw "%" as
+    // %25) and the relax replacement happen in ONE function, so %2C / %7E can
+    // only ever be the encoder's own escapes. Strings are rejected: relaxing a
+    // pre-built string is exactly the unsafe operation this API exists to
+    // prevent.
+    function serialize(params) {
+      if (!(params instanceof URLSearchParams)) {
+        if (typeof FormData !== "undefined" && params instanceof FormData) {
+          params = new URLSearchParams(params);
+        } else {
+          throw new TypeError("wsjrdpRelaxedQuery expects URLSearchParams or FormData, got " + typeof params);
+        }
+      }
+      return params.toString().replace(/%2C/gi, ",").replace(/%7E/gi, "~");
+    }
+    // URL -> relative href (path + relaxed query + hash). Reassembles from the
+    // components so the replacement only ever touches the query part, never
+    // path or fragment octets.
+    function href(url) {
+      if (!(url instanceof URL)) {
+        throw new TypeError("wsjrdpRelaxedQuery.href expects a URL, got " + typeof url);
+      }
+      // A pathname may start with "//" (WHATWG keeps an empty first segment, e.g.
+      // new URL("https://app//evil.example/x").pathname === "//evil.example/x").
+      // Returned as-is that would be a protocol-relative (network-path) reference
+      // resolving to ANOTHER ORIGIN -- an open-redirect primitive. Collapse the
+      // leading slashes so the result is always same-origin-relative.
+      var path = url.pathname.replace(/^\/{2,}/, "/");
+      var qs = serialize(url.searchParams);
+      return path + (qs ? "?" + qs : "") + url.hash;
+    }
+    window.wsjrdpRelaxedQuery = { serialize: serialize, href: href };
+  })();
+  // wsjrdp-relaxed-query-end

--- a/doc/url_encoding.md
+++ b/doc/url_encoding.md
@@ -1,0 +1,347 @@
+# URL query encoding — policy & reference
+
+> **Note:** this document was written largely by Claude (AI), reviewed by a
+> human. The encoder tables were produced by measuring the actual functions in
+> this project's Ruby and Node versions, not from memory — but if a statement
+> here ever contradicts what you observe, trust the code and fix the page.
+
+How we percent-encode (and deliberately *don't* over-encode) characters in URL
+query strings, why, and the **mandatory** helper pattern that makes relaxing the
+encoding safe. The last section (Encapsulation) has real security implications —
+follow it without exception.
+
+## 1. Policy (must follow)
+
+- **The verified set — must be literal.** Characters that RFC 3986 permits
+  unencoded, that we do not use as structural separators, **and that we have
+  verified end-to-end** — today exactly `,` and `~` — **must be left literal**
+  in the URLs this wagon builds, not percent-encoded. Result: short, readable
+  URLs like `?sort=bez,nr~` instead of `?sort=bez%2Cnr%7E`. You discharge this
+  obligation by building the URL through the mandatory helpers (§6) — **never**
+  by writing your own decode step.
+- **Candidates — may be added, only via §6.1.** The other RFC-legal sub-delims
+  (`! $ ' ( ) * ;`) are permissible in principle but are **not** relaxed today
+  and must stay encoded until they go through the §6.1 process. `;` in
+  particular has a history as a query separator outside Rack (proxies, WAFs,
+  legacy middleware), so it stays encoded until the whole chain is verified —
+  Rack alone is not enough.
+- **Never relax these.** `&`, `=`, `+`/`%2B`, `#`, `%` (always `%25`), and
+  anything non-ASCII must never be added to the relax set: they carry
+  x-www-form-urlencoded or URI structure. Brackets `[` `]` likewise — they are
+  gen-delims and encode Rack's param nesting (`show[active_zero]=1`).
+  - *Nuance for space:* our encoders emit a space as a literal `+` (not `%20`) —
+    that is form-urlencoding, not a relax, and it round-trips correctly. What
+    must never be relaxed is `%2B`, i.e. a plus **in the data**.
+- **Safe default — when unsure, do not relax.** An over-encoded URL is always
+  functionally correct: Rack decodes `%2C` and `,` to the same value, so
+  relaxing is purely a readability win. If your case does not fit
+  `RelaxedUrlQuery.to_query` / `wsjrdpRelaxedQuery`, emit the fully encoded form
+  and raise it in review — do not improvise.
+- Note: some browsers percent-decode parts of the URL for address-bar *display*
+  (though Firefox and Chromium both keep `%2C` encoded), so the visible bar is
+  not the point. The literal form is what lands in copied and shared links,
+  generated mails, server logs, and spec expectations.
+
+**Scope.** This policy governs URL-building code **in this wagon** (Ruby helpers
+and controllers, and the inline JS partials). The hitobito core is read-only for
+us — never patch core merely to relax its URLs. URLs from any other producer
+(core, the `wsjrdp_scripts` Python tooling, mail templates, external links) are
+out of scope and MAY over-encode freely; the server accepts both spellings.
+
+## 2. Why leaving these literal is safe here
+
+- **RFC 3986 query grammar** (§3.4): `query = *( pchar / "/" / "?" )` with
+  `pchar = unreserved / pct-encoded / sub-delims / ":" / "@"`. So every sub-delim
+  (`! $ & ' ( ) * + , ; =`) and every unreserved char (incl. `~`) is valid
+  *literally* in a query. Percent-encoding them is allowed but **not required**.
+- **Our parser is Rack** (Rails). `Rack::Utils.parse_nested_query` splits a query
+  on `&` only; it never splits a value on `,` / `;` / etc. So a literal `,`
+  round-trips to exactly the same string as `%2C`.
+  - Caveat: `;` is safe under *current Rack* only — Rack 2.1 made `&` the sole
+    default separator and Rack 3 removed `;` handling entirely. That covers our
+    parser, not the rest of the chain (see §1: `;` stays encoded).
+
+## 3. RFC 3986 character classes (quick reference)
+
+```
+unreserved  = A-Z a-z 0-9 - . _ ~                 (never needs encoding)
+reserved    = gen-delims / sub-delims
+  gen-delims = :  /  ?  #  [  ]  @
+  sub-delims = !  $  &  '  (  )  *  +  ,  ;  =
+pct-encoded = "%" HEXDIG HEXDIG                    (a literal "%" MUST be "%25")
+```
+
+Specs & docs:
+
+- RFC 3986 — URI generic syntax (§2.2 reserved, §2.3 unreserved, §3.4 query):
+  <https://www.rfc-editor.org/rfc/rfc3986#section-2.2>
+- WHATWG URL Standard — `URL`, `URLSearchParams`, the percent-encode sets, and
+  `application/x-www-form-urlencoded`: <https://url.spec.whatwg.org/>
+- MDN `encodeURIComponent`:
+  <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent>
+- MDN `encodeURI`:
+  <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI>
+- MDN `URLSearchParams`:
+  <https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams>
+- Ruby `CGI.escape` / `CGI.escapeURIComponent`:
+  <https://docs.ruby-lang.org/en/master/CGI.html>
+- Ruby `URI.encode_www_form_component`:
+  <https://docs.ruby-lang.org/en/master/URI.html#method-c-encode_www_form_component>
+- Ruby `ERB::Util.url_encode`:
+  <https://docs.ruby-lang.org/en/master/ERB/Util.html#method-c-url_encode>
+- Rails `Object#to_query` / `Hash#to_query`:
+  <https://api.rubyonrails.org/classes/Object.html#method-i-to_query>
+- `Rack::Utils.escape`:
+  <https://www.rubydoc.info/gems/rack/Rack/Utils#escape-class_method>
+
+## 4. What each encoder actually does
+
+The point of interest: which of the "leave-literal" chars a function still
+percent-encodes (over-encoding, relative to RFC 3986), and whether it even
+encodes an **unreserved** char (`~`). Space handling differs too (`+` vs `%20`).
+
+The two wide columns cover every gen-delim, every sub-delim and `~`; the narrow
+`encodes …` columns repeat the characters we care about most, for quick lookup
+(**yes** = percent-encoded, no = left literal). Alphanumerics and `- . _` are
+kept by every encoder listed and are therefore omitted.
+
+### JavaScript (measured on Node 26; matches WHATWG/MDN)
+
+| function | keeps literal | encodes | `~` | `,` | `!` | `(` | `)` | `$` | `'` | `*` | space |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| [`encodeURIComponent`][enc-uri-component] | `! ' ( ) * ~` | `: / ? # [ ] @ $ & + , ; =` | no | **yes** | no | no | no | **yes** | no | no | `%20` |
+| [`encodeURI`][enc-uri] | `: / ? # @ ! $ & ' ( ) * + , ; = ~` | `[ ]` | no | no | no | no | no | no | no | no | `%20` |
+| [`URLSearchParams`][urlsearchparams] / mutating `URL.searchParams` | `*` | `: / ? # [ ] @ ! $ & ' ( ) + , ; = ~` | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | no | `+` |
+
+- [`encodeURIComponent`][enc-uri-component] uses the old RFC 2396 "mark" set: it keeps `! ~ * ' ( )`
+  but still encodes `, ; $` (and `& + = : @ / ? #`). Fine for splicing a single
+  value into an already-relaxed URL template.
+- [`encodeURI`][enc-uri] is for whole URIs, not for values: it preserves every reserved
+  character (so a `&` or `=` inside a value would stay structural) and escapes
+  only `[ ]` plus the non-ASCII/space range. Never use it on a single param
+  value.
+- [`URLSearchParams.toString()`][urlsearchparams] is `application/x-www-form-urlencoded`: it encodes
+  `~` (an **unreserved** char) and every sub-delim except `*`; space → `+`. It is
+  what the JS helper builds on. **Mutating `URL.searchParams` re-serialises the
+  *whole* query this way** — which is why a previously literal `sort=bez,nr~`
+  turns into `bez%2Cnr%7E` after you touch one unrelated param.
+
+### Ruby (measured on Ruby 3.2.9 in this project)
+
+| function | keeps literal | encodes | `~` | `,` | `!` | `(` | `)` | `$` | `'` | `*` | space |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| [`CGI.escape`][cgi] | `~` | `: / ? # [ ] @ ! $ & ' ( ) * + , ; =` | no | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | `+` |
+| [`Object#to_query`][to-query] / [`Hash#to_query`][to-query] (uses [`CGI.escape`][cgi]) | `~` | `: / ? # [ ] @ ! $ & ' ( ) * + , ; =` | no | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | `+` |
+| [`URI.encode_www_form_component`][uri-www-form-component] | `*` | `: / ? # [ ] @ ! $ & ' ( ) + , ; = ~` | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | no | `+` |
+| [`Rack::Utils.escape`][rack-escape] (same as [`URI.encode_www_form_component`][uri-www-form-component]) | `*` | `: / ? # [ ] @ ! $ & ' ( ) + , ; = ~` | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | no | `+` |
+| [`ERB::Util.url_encode`][erb-url-encode] | `~` | `: / ? # [ ] @ ! $ & ' ( ) * + , ; =` | no | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | `%20` |
+| [`CGI.escapeURIComponent`][cgi] (Ruby ≥ 3.2) | `~` | `: / ? # [ ] @ ! $ & ' ( ) * + , ; =` | no | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | **yes** | `%20` |
+
+- **None** of the Ruby encoders leave the sub-delims `! $ ' ( ) , ;` literal —
+  they all over-encode them relative to RFC 3986.
+- The unreserved `~` is **encoded** (`%7E`) by [`URI.encode_www_form_component`][uri-www-form-component]
+  and [`Rack::Utils.escape`][rack-escape], but kept literal by [`CGI.escape`][cgi] / [`to_query`][to-query] /
+  [`ERB::Util.url_encode`][erb-url-encode] / [`CGI.escapeURIComponent`][cgi].
+- Used in the code: [`Hash#to_query`][to-query] is what `RelaxedUrlQuery` (§6) builds on —
+  the `%2C`/`%7E` it produces are relaxed straight back, so URLs built through
+  that helper carry the literal form. `URI.encode_www_form` is used directly in
+  `Person::FeeController` (note it encodes `~`; those are plain button links,
+  not list params, so only functional correctness matters there).
+- A codebase may also grow its own **encode-forward** helper that deliberately
+  under-encodes a single value (leaving e.g. `=` or non-ASCII literal). That can
+  be legitimate — Rack and [`URLSearchParams`][urlsearchparams] split each `name=value` pair on the
+  **first** `=` only, and both pass UTF-8 through — but it is an *encoder*, never
+  a relax step, so §6 does not apply to it. Document any such helper here.
+- `ERB::Util.html_escape` is **HTML** escaping, not URL encoding — different
+  concern, don't confuse them.
+
+## 5. Relaxing (reversing) the over-encoding
+
+To get the RFC-clean literal form after encoding, decode the `%XX` escapes for
+the chars you want literal. The exact escapes depend on the encoder:
+
+| char | escape | produced by |
+|---|---|---|
+| `,` | `%2C` | all encoders above **except [`encodeURI`][enc-uri]**, which keeps `,` literal |
+| `~` | `%7E` | [`URLSearchParams`][urlsearchparams], [`URI.encode_www_form_component`][uri-www-form-component], [`Rack::Utils.escape`][rack-escape] (the others already keep `~`) |
+| `!` `$` `'` `(` `)` `*` `;` | `%21 %24 %27 %28 %29 %2A %3B` | relax only those you actually use |
+
+Today we produce and relax exactly `%2C` → `,` and `%7E` → `~`.
+
+## 6. Encapsulation rule — SECURITY, no exceptions
+
+Relaxing means string-replacing `%XX` back to a literal char. **This is safe only
+on the output of a proper percent-encoder.** In such output `%` is guaranteed to
+be encoded as `%25`, so `%` never appears raw: every `%` starts a `%XX` triplet,
+and `%2C` / `%7E` can only ever be the escape of a comma / tilde. (A literal
+`%2C` in the *data* is encoded to `%25`​`2C`, which contains no `%2C` substring —
+so it is not mis-decoded.)
+
+*Proper* is a checkable property, not a vibe: the encoder must percent-encode
+**every** raw `%` in its input as `%25`, unconditionally — `enc("%2C")` must
+yield `%252C`. Escape-preserving (idempotent) encoders — anything with
+"skip already-encoded sequences" behaviour, e.g. `Addressable::URI`
+normalization or hand-rolled `%(?![0-9A-Fa-f]{2})`-style helpers — do **not**
+have this property and must never feed a relax step: in their output `%2C` can
+be data, which the relax then corrupts. Every function in the §4 tables *does*
+have the property; anything not listed there must be verified before it may ever
+feed a relax. Rule 3's round-trip tests — especially "the text `%2C` as data" —
+are what catch a violation.
+
+Run the same replace on a **raw or partly-decoded** string that may contain a
+bare `%`, and you can corrupt data or **forge separators**. The danger grows the
+moment the relax set is widened: relax `,`/`~` on a raw value and at worst a
+literal `%2C`/`%7E` in the data turns into `,`/`~` (harmless — Rack never splits
+on those); but relax a separator like `&` (`%26`) or `=` (`%3D`) on raw input and
+a value's literal `%26` collapses into a real `&`, splitting off a forged
+parameter. That is a genuine parameter-injection risk — which is exactly why the
+relax step must never see anything but fresh encoder output.
+
+Therefore, **mandatory**:
+
+1. **Encode and relax in ONE helper.** The relax `.gsub` / `.replace` must only
+   ever be fed the *immediate* output of the encoder. Never write a standalone
+   "relax this string" function, and never call the `%XX` replace on a value that
+   did not come straight out of an encoder in the same expression/helper.
+2. **Relax the query component only** — never regex the whole URL string (a path
+   or fragment octet must stay as-is). On the client, run the replace on
+   `searchParams.toString()` and reassemble `path + "?" + query + hash`; never on
+   `url.toString()`.
+   - *Destination assembly:* build the path part only from a component that
+     cannot itself contain a `?` (`URL.pathname`, `location.pathname`,
+     `request.path`) — never concatenate `"?" + query` onto something that might
+     already carry one (`request.fullpath`, an `action` attribute, an `href`).
+     When you hold a `URL`, use `wsjrdpRelaxedQuery.href()` rather than
+     concatenating by hand.
+   - *Protocol-relative edge:* a `pathname` may begin with `//` (WHATWG keeps an
+     empty first segment: `new URL("https://app//evil.example/x").pathname ===
+     "//evil.example/x"`). Returned as-is that is a network-path reference that
+     resolves to **another origin** — an open-redirect primitive. `href()`
+     collapses leading slashes; any hand-rolled assembly must do the same.
+3. **Any new or copied helper of this kind must be extensively tested and
+   documented.** Round-trip tests at minimum: `value → encode+relax → parse back
+   == value` for tricky inputs including a literal `%`, the text `%2C` as data,
+   `&`, `=`, `+`, space, and non-ASCII. No exceptions.
+4. **Do not scatter** raw `.gsub("%2C", ",")` calls. If you need this behaviour in
+   a new place, route it through a single tested helper rather than copying the
+   inline expression.
+5. **This is enforced, not just asked.** `spec/models/url_encoding_guard_spec.rb`
+   scans `app/` and `lib/` (`.rb`, `.haml`, `.erb`, `.js`) and fails on any
+   percent-escape replacement outside the two mandatory helpers. If it flags your
+   change, call `RelaxedUrlQuery` / `wsjrdpRelaxedQuery` instead. Extending the
+   guard's allowlist is itself a policy change — see §6.1.
+
+### 6.1 Widening the relax set — decision rule & checklist
+
+A character MAY be added to the relax set only if **all** of these hold:
+
+1. **RFC 3986 permits it literally in a query** (§3: unreserved or sub-delim).
+   Gen-delims (`: / ? # [ ] @`) never qualify; `[` `]` are additionally
+   structural for Rack's param nesting.
+2. **No decoder in the chain treats it as a separator** — and "the chain" is not
+   just Rack: reverse proxy, CDN/cache, WAF, and log tooling all parse these
+   URLs. *Verify* concretely: add literal-in-value **and** "X as data"
+   round-trip cases to **both** test matrices and to both fuzz charsets, and
+   confirm they pass. For `;` additionally confirm the deployed Rack major
+   version (≥ 3 removed `;` handling) *and* the non-Rack hops.
+3. **We actually emit the character** in a list-style param — never relax
+   speculatively.
+
+One PR must change together: `RELAXATIONS` (+ its comment), the JS replace
+chain, both test suites, and this document. When in doubt, don't — see the safe
+default in §1.
+
+### The mandatory helpers (use these, never inline the pattern)
+
+Exactly one implementation exists per language. **Always call these; never write
+a new inline `gsub`/`replace` of `%XX` sequences.**
+
+- **Ruby** — [`RelaxedUrlQuery`](../app/models/relaxed_url_query.rb)
+  (`app/models/relaxed_url_query.rb`): the only public API is
+  `RelaxedUrlQuery.to_query(params_hash)` → query string with `,`/`~` literal.
+  Encode ([`Hash#to_query`][to-query]) and relax are one method; it **raises `TypeError` on
+  anything but a Hash**, so a pre-built string can never reach the relax, and the
+  relax pieces are `private_constant` so they cannot be reassembled from outside.
+  Typical use in a URL-building helper:
+
+  ```ruby
+  "#{request.path}?#{RelaxedUrlQuery.to_query(query_params)}"
+  ```
+
+  Tests: `spec/models/relaxed_url_query_spec.rb` — readability, round-trips
+  through `Rack::Utils.parse_nested_query` for raw `%`, the literal text
+  `%2C`/`%7E` as data, separators (`&`, `=`, `+`, `#`), non-ASCII, nested
+  hashes/arrays, hostile injection values, a 500-case seeded fuzz, and the
+  API-surface assertions. Deliberately standalone (no Rails boot, no DB — also
+  so a test run can never be pointed at a shared dev database):
+
+  ```bash
+  # from the core app directory, inside the dev container
+  bundle exec rspec ../hitobito_wsjrdp_2027/spec/models/relaxed_url_query_spec.rb
+  ```
+
+- **JavaScript** — `window.wsjrdpRelaxedQuery`
+  ([`app/views/shared/_relaxed_query_js.html.haml`](../app/views/shared/_relaxed_query_js.html.haml)):
+  `serialize(URLSearchParams | FormData)` → relaxed query string, and
+  `href(URL)` → `pathname + "?" + relaxed query + hash`. Both **throw a
+  `TypeError` on plain strings** — the API only accepts structured input, so the
+  replacement can never run on a string with a raw `%`; `href` reassembles from
+  components (so path/fragment octets are never touched) and collapses a leading
+  `//` so its result can never be a cross-origin network-path reference. Render
+  the partial (`= render "shared/relaxed_query_js"`, idempotent per
+  request/page) before any script that uses it — typically from an inline
+  `:javascript` block that rewrites the URL (`history.replaceState`) or builds a
+  navigation target from form fields.
+
+  Tests: `spec/javascripts/relaxed_query.test.mjs` mirrors the Ruby matrix and
+  adds the type-contract and protocol-relative checks; it extracts the
+  implementation from the partial's marker comments, so partial and test cannot
+  drift apart:
+
+  ```bash
+  # from the wagon root; no dependencies (built-in node runner).
+  # Quote the glob -- a bare directory argument does not work.
+  node --test "spec/javascripts/**/*.test.mjs"
+  ```
+
+Both suites run in CI: the Ruby one as part of the wagon specs, the JS one in the
+`javascript specs` job of `.github/workflows/wagon-tests.yml`. Changing either
+helper (especially widening the relax set, §6.1) requires extending BOTH suites
+first; run them plus `bundle exec rubocop -a .` before committing.
+
+**Adopting the helpers.** Existing code that builds a query with a plain
+[`Hash#to_query`][to-query] (redirect targets, link helpers) is not broken — it just emits
+the over-encoded spelling, which the server accepts (§2). Migrate such a site to
+`RelaxedUrlQuery.to_query` when you touch it; never "fix" it with an inline
+relax (§6). Keep a list of the remaining ones here as they are found.
+
+## 7. Operational notes
+
+- **Two spellings, one page.** The encoded and relaxed forms are different
+  *strings* but identical to the server (§2). Old bookmarks and externally
+  generated links in the encoded form keep working; we never redirect to
+  normalize. Consequence: client-side URL-string consumers (Turbo's page cache,
+  history entries, analytics) may see both variants of the same page. Expected
+  and harmless.
+- **Never compare URLs as strings.** In JS and in specs, parse and compare
+  params ([`URLSearchParams`][urlsearchparams], `Rack::Utils.parse_nested_query`) instead of
+  matching query strings textually — a comparison written against one spelling
+  breaks intermittently against the other.
+- **Searching logs.** Access logs contain whichever form the client sent, so
+  grep for both (e.g. `sort=bez,nr~` *and* `sort=bez%2Cnr%7E`) when tracing a
+  request.
+- **Application-level separators.** §2 argues transport safety only: a literal
+  `,`/`~` parses to the same param *value* as `%2C`/`%7E`. But a list-style param
+  typically uses `,` and `~` as its **own** separators inside that value (a comma
+  list, a `~` marker). So the tokens themselves — column keys, sort symbols, row
+  ids — must never contain `,` or `~`, or the value is silently mis-parsed. Keep
+  such tokens `[a-z0-9_]`, and assert it where the tokens are defined.
+
+[enc-uri-component]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+[enc-uri]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
+[urlsearchparams]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
+[cgi]: https://docs.ruby-lang.org/en/master/CGI.html
+[uri-www-form-component]: https://docs.ruby-lang.org/en/master/URI.html#method-c-encode_www_form_component
+[erb-url-encode]: https://docs.ruby-lang.org/en/master/ERB/Util.html#method-c-url_encode
+[to-query]: https://api.rubyonrails.org/classes/Object.html#method-i-to_query
+[rack-escape]: https://www.rubydoc.info/gems/rack/Rack/Utils#escape-class_method

--- a/spec/javascripts/relaxed_query.test.mjs
+++ b/spec/javascripts/relaxed_query.test.mjs
@@ -1,0 +1,216 @@
+//  Copyright (c) 2026 German Contingent for the World Scout Jamboree 2027.
+//
+//  This file is part of hitobito_wsjrdp_2027 and licensed under the
+//  Affero General Public License version 3 or later. See the COPYING
+//  file at the top-level directory or at
+//  https://github.com/smeky42/hitobito_wsjrdp_2027
+
+// Tests for window.wsjrdpRelaxedQuery (doc/url_encoding.md §6). The
+// implementation lives INSIDE app/views/shared/_relaxed_query_js.html.haml (a
+// :javascript filter block); this test extracts the code between its
+// wsjrdp-relaxed-query-begin/end markers and runs it against a fresh fake
+// `window`, so partial and test cannot drift apart silently.
+//
+// Run (no dependencies, built-in runner), from the wagon root:
+//   node --test "spec/javascripts/**/*.test.mjs"
+// (Quote the glob so node expands it. A bare directory argument does not work.)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PARTIAL = join(dirname(fileURLToPath(import.meta.url)),
+  "../../app/views/shared/_relaxed_query_js.html.haml");
+
+function loadHelper() {
+  const source = readFileSync(PARTIAL, "utf8");
+  const match = source.match(
+    /\/\/ wsjrdp-relaxed-query-begin\n([\s\S]*?)\/\/ wsjrdp-relaxed-query-end/
+  );
+  assert.ok(match, "marker comments not found in _relaxed_query_js.html.haml");
+  const window = {};
+  new Function("window", match[1])(window);
+  assert.ok(window.wsjrdpRelaxedQuery, "helper did not install itself");
+  return window.wsjrdpRelaxedQuery;
+}
+
+const helper = loadHelper();
+
+// Parse a query string back the way our stack does (URLSearchParams splits on
+// "&" / "=", percent-decodes, "+" -> space -- same as Rack for these cases).
+const parseBack = (qs) => new URLSearchParams(qs);
+
+// ---------------------------------------------------------------- readability
+
+test("keeps , and ~ literal in values", () => {
+  const qs = helper.serialize(new URLSearchParams({ sort: "bez,nr~" }));
+  assert.equal(qs, "sort=bez,nr~");
+});
+
+test("keeps , and ~ literal across several params (sort + cols)", () => {
+  const sp = new URLSearchParams();
+  sp.set("sort", "bez~,cnt~");
+  sp.set("cols", "nr,bez,~st,sum,cnt");
+  const qs = helper.serialize(sp);
+  assert.equal(qs, "sort=bez~,cnt~&cols=nr,bez,~st,sum,cnt");
+  assert.ok(!/%2C|%7E/i.test(qs));
+});
+
+test("empty params serialize to the empty string", () => {
+  assert.equal(helper.serialize(new URLSearchParams()), "");
+});
+
+// ---------------------------------------------------- round-trip (the security property)
+
+const ROUNDTRIP_VALUES = [
+  "hello",
+  "a,b,c",
+  "x~y~",
+  "100%",
+  "%",
+  "%2C",            // encoded comma as DATA -- must survive as the 3-char text
+  "%7E",
+  "%2c%7e",
+  "%252C",          // double encoded
+  "a&b=c",
+  "a=b",
+  "1+1=2",
+  "a#frag",
+  "a b",
+  "a;b",
+  "a?b",
+  "!$&'()*+,;=",    // all sub-delims
+  ":/?#[]@",        // gen-delims
+  "Zäune, Bäume & Käfer ~ 100%",
+  "🏕️,~%",
+  "a\nb\tc",
+  "x%26evil%3D1"    // injection attempt -- must NOT become a new param
+];
+
+for (const value of ROUNDTRIP_VALUES) {
+  test(`round-trips ${JSON.stringify(value)}`, () => {
+    const qs = helper.serialize(new URLSearchParams({ v: value }));
+    assert.equal(parseBack(qs).get("v"), value);
+  });
+}
+
+test("round-trips keys containing , ~ % & =", () => {
+  const sp = new URLSearchParams();
+  for (const [k, v] of [["a,b", "1"], ["c~d", "2"], ["e%f", "3"], ["g&h", "4"], ["i=j", "5"]]) {
+    sp.set(k, v);
+  }
+  const parsed = parseBack(helper.serialize(sp));
+  assert.deepEqual([...parsed.entries()],
+    [["a,b", "1"], ["c~d", "2"], ["e%f", "3"], ["g&h", "4"], ["i=j", "5"]]);
+});
+
+test("never splits off a forged parameter from hostile values", () => {
+  const parsed = parseBack(helper.serialize(new URLSearchParams({ q: "evil=1&admin=true" })));
+  assert.deepEqual([...parsed.keys()], ["q"]);
+  assert.equal(parsed.get("q"), "evil=1&admin=true");
+});
+
+test("round-trips repeated params (arrays)", () => {
+  const sp = new URLSearchParams();
+  for (const v of ["a,1", "b~2", "100%"]) sp.append("account_number[]", v);
+  const parsed = parseBack(helper.serialize(sp));
+  assert.deepEqual(parsed.getAll("account_number[]"), ["a,1", "b~2", "100%"]);
+});
+
+test("accepts FormData", () => {
+  const fd = new FormData();
+  fd.append("sort", "bez,nr~");
+  fd.append("q", "100% & more");
+  const qs = helper.serialize(fd);
+  const parsed = parseBack(qs);
+  assert.equal(parsed.get("sort"), "bez,nr~");
+  assert.equal(parsed.get("q"), "100% & more");
+  assert.ok(qs.includes("sort=bez,nr~"));
+});
+
+// --------------------------------------------------------- deterministic fuzz
+
+function mulberry32(seed) {
+  return function () {
+    seed |= 0; seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+test("round-trips 500 fuzzed adversarial values byte-identically", () => {
+  const charset = ["a", "b", "c", "0", "9", "%", ",", "~", "&", "=", "+", "#",
+    " ", ";", "'", "(", ")", "*", "!", "$", "[", "]", "ü", "€", "\\", '"'];
+  const rand = mulberry32(20260823); // fixed seed -> reproducible failures
+  for (let i = 0; i < 500; i++) {
+    const len = Math.floor(rand() * 25);
+    let value = "";
+    for (let j = 0; j < len; j++) value += charset[Math.floor(rand() * charset.length)];
+    const qs = helper.serialize(new URLSearchParams({ v: value }));
+    assert.equal(parseBack(qs).get("v"), value, `fuzz #${i} failed for ${JSON.stringify(value)}`);
+  }
+});
+
+// ------------------------------------------------------------- href assembly
+
+test("href assembles path + relaxed query + hash", () => {
+  const url = new URL("http://x.test/bookkeeping/cost_centers?sort=bez%2Ccnt%7E&per=all#frag");
+  assert.equal(helper.href(url), "/bookkeeping/cost_centers?sort=bez,cnt~&per=all#frag");
+});
+
+test("href omits the ? when the query is empty", () => {
+  assert.equal(helper.href(new URL("http://x.test/foo")), "/foo");
+});
+
+test("href never touches path or fragment octets", () => {
+  const url = new URL("http://x.test/pa%2Cth/x?open=1%2C2#a%2Cb");
+  const result = helper.href(url);
+  assert.ok(result.startsWith("/pa%2Cth/x?"), "path must stay encoded");
+  assert.ok(result.endsWith("#a%2Cb"), "fragment must stay as-is");
+  assert.ok(result.includes("open=1,2"), "query must be relaxed");
+});
+
+// A pathname beginning with "//" would make the result a protocol-relative
+// (network-path) reference resolving to another origin -- an open redirect.
+test("href never returns a protocol-relative reference", () => {
+  for (const raw of ["http://app.test//evil.example/x?a=1",
+    "http://app.test///evil.example/x",
+    "http://app.test//evil.example"]) {
+    const url = new URL(raw);
+    assert.ok(url.pathname.startsWith("//"), `precondition: ${raw} has // pathname`);
+    const result = helper.href(url);
+    assert.ok(!result.startsWith("//"), `must not be protocol-relative: ${result}`);
+    assert.ok(result.startsWith("/"), `must stay origin-relative: ${result}`);
+    // resolves back to our own origin, not the injected one
+    assert.equal(new URL(result, "http://app.test").origin, "http://app.test");
+  }
+});
+
+test("href leaves ordinary single-slash paths untouched", () => {
+  const url = new URL("http://app.test/bookkeeping/suppliers?sort=bez%2Cnr%7E");
+  assert.equal(helper.href(url), "/bookkeeping/suppliers?sort=bez,nr~");
+});
+
+// ------------------------------------------- encapsulation (API contract)
+
+test("serialize throws on plain strings (raw-string relax is forbidden)", () => {
+  assert.throws(() => helper.serialize("sort=bez%2Cnr"), TypeError);
+});
+
+test("serialize throws on null / undefined / objects", () => {
+  for (const bad of [null, undefined, 42, { sort: "x" }, ["a", "b"]]) {
+    assert.throws(() => helper.serialize(bad), TypeError, `should throw for ${String(bad)}`);
+  }
+});
+
+test("href throws on non-URL input", () => {
+  assert.throws(() => helper.href("/foo?a=1"), TypeError);
+  assert.throws(() => helper.href({ pathname: "/x", searchParams: new URLSearchParams(), hash: "" }), TypeError);
+});
+
+test("exposes exactly serialize and href", () => {
+  assert.deepEqual(Object.keys(helper).sort(), ["href", "serialize"]);
+});

--- a/spec/models/relaxed_url_query_spec.rb
+++ b/spec/models/relaxed_url_query_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026 German Contingent for the World Scout Jamboree 2027.
+#
+#  This file is part of hitobito_wsjrdp_2027 and licensed under the
+#  Affero General Public License version 3 or later. See the COPYING
+#  file at the top-level directory or at
+#  https://github.com/smeky42/hitobito_wsjrdp_2027
+
+# Deliberately standalone (no rails spec_helper): RelaxedUrlQuery is pure, the
+# spec needs neither the app nor a database -- and the full test boot must never
+# be pointed at a shared dev DB by accident. Runs against any bundle that has
+# activesupport + rack + rspec, e.g. from the core app directory:
+#
+#   bundle exec rspec ../hitobito_wsjrdp_2027/spec/models/relaxed_url_query_spec.rb
+require "active_support"
+require "active_support/core_ext/object/to_query"
+require "rack/utils"
+require_relative "../../app/models/relaxed_url_query"
+
+# Round-trip safety of the relaxed query encoding (doc/url_encoding.md §6):
+# every value -- including raw "%", the literal text "%2C"/"%7E", separators and
+# non-ASCII -- must come back byte-identical through Rack's parser, while "," and
+# "~" stay literal (readable) in the produced query string.
+describe RelaxedUrlQuery do
+  def roundtrip(params)
+    Rack::Utils.parse_nested_query(RelaxedUrlQuery.to_query(params))
+  end
+
+  # What Rack hands the app back for `params`: string keys/values.
+  def stringified(params)
+    params.to_h { |k, v| [k.to_s, v.is_a?(Array) ? v.map(&:to_s) : v.to_s] }
+  end
+
+  describe "readability (the point of the relaxing)" do
+    it "keeps , and ~ literal in values" do
+      expect(RelaxedUrlQuery.to_query(sort: "bez,nr~")).to eq("sort=bez,nr~")
+    end
+
+    it "keeps , and ~ literal across several params (A-Rison sort + cols)" do
+      query = RelaxedUrlQuery.to_query("sort" => "bez~,cnt~", "cols" => "nr,bez,~st,sum,cnt")
+      expect(query).to eq("cols=nr,bez,~st,sum,cnt&sort=bez~,cnt~")
+      expect(query).not_to include("%2C", "%7E")
+    end
+
+    it "returns an empty string for empty params" do
+      expect(RelaxedUrlQuery.to_query({})).to eq("")
+    end
+  end
+
+  describe "round-trip safety (the security property)" do
+    [
+      {"plain" => "hello"},
+      {"comma" => "a,b,c"},
+      {"tilde" => "x~y~"},
+      {"raw percent" => "100%"},
+      {"lone percent" => "%"},
+      {"encoded comma as DATA" => "%2C"},          # must survive as the 3-char text
+      {"encoded tilde as DATA" => "%7E"},
+      {"lowercase escapes as DATA" => "%2c%7e"},
+      {"double encoded" => "%252C"},
+      {"ampersand" => "a&b=c"},
+      {"equals" => "a=b"},
+      {"plus" => "1+1=2"},
+      {"hash" => "a#frag"},
+      {"space" => "a b"},
+      {"semicolon" => "a;b"},
+      {"question mark" => "a?b"},
+      {"all sub-delims" => "!$&'()*+,;="},
+      {"gen-delims" => ":/?#[]@"},
+      {"non-ascii" => "Zäune, Bäume & Käfer ~ 100%"},
+      {"emoji" => "🏕️,~%"},
+      {"newline & control" => "a\nb\tc"},
+      {"injection attempt" => "x%26evil%3D1"}      # must NOT become a new param
+    ].each do |params|
+      it "round-trips #{params.keys.first.inspect} => #{params.values.first.inspect}" do
+        expect(roundtrip(params)).to eq(params)
+      end
+    end
+
+    it "round-trips keys containing , ~ % & =" do
+      params = {"a,b" => "1", "c~d" => "2", "e%f" => "3", "g&h" => "4", "i=j" => "5"}
+      expect(roundtrip(params)).to eq(params)
+    end
+
+    it "never splits off a forged parameter from hostile values" do
+      parsed = roundtrip("q" => "evil=1&admin=true")
+      expect(parsed.keys).to eq(["q"])
+      expect(parsed["q"]).to eq("evil=1&admin=true")
+    end
+
+    it "round-trips array params" do
+      expect(roundtrip("account_number" => ["a,1", "b~2", "100%"]))
+        .to eq("account_number" => ["a,1", "b~2", "100%"])
+    end
+
+    it "round-trips nested hashes (the suppliers show[...] grid)" do
+      params = {"grid" => "1", "show" => {"active_zero" => "1", "deactivated_balance" => "1"}}
+      expect(roundtrip(params)).to eq(params)
+    end
+
+    it "round-trips non-string scalars as their string form" do
+      expect(roundtrip(page: 2, per: "all")).to eq(stringified(page: 2, per: "all"))
+    end
+  end
+
+  describe "deterministic fuzz (500 adversarial values)" do
+    let(:charset) do
+      [*"a".."f", *"0".."9", "%", ",", "~", "&", "=", "+", "#", " ", ";",
+        "'", "(", ")", "*", "!", "$", "[", "]", "ü", "€", "\\", '"'].freeze
+    end
+
+    it "round-trips every fuzzed value byte-identically" do
+      rng = Random.new(20_260_823) # fixed seed -> reproducible failures
+      500.times do |i|
+        value = Array.new(rng.rand(0..24)) { charset[rng.rand(charset.size)] }.join
+        expect(roundtrip("v" => value)).to eq({"v" => value}),
+          "fuzz ##{i} failed for value #{value.inspect}"
+      end
+    end
+  end
+
+  describe "encapsulation (no raw-string relax API)" do
+    it "exposes only to_query -- no public method accepts a pre-built string" do
+      expect(RelaxedUrlQuery.singleton_methods(false)).to contain_exactly(:to_query)
+    end
+
+    it "only relaxes characters that are provably separator-free" do
+      expect(RelaxedUrlQuery.const_get(:RELAXATIONS).values).to all(match(/\A[,~]\z/))
+    end
+
+    # The relax pieces must not be reachable from outside: otherwise
+    # `str.gsub(RelaxedUrlQuery::RELAXATION_PATTERN, RelaxedUrlQuery::RELAXATIONS)`
+    # would be exactly the forbidden raw-string relax, assembled past to_query.
+    # (Note: Module#const_get deliberately bypasses privacy -- the scope
+    # resolution operator is what enforces it, so that is what we assert.)
+    [:RELAXATIONS, :RELAXATION_PATTERN].each do |const|
+      it "keeps #{const} private" do
+        expect(RelaxedUrlQuery.const_get(const)).not_to be_nil # it exists ...
+        # ... but is unreachable from outside. const_get deliberately bypasses
+        # privacy, so the scope resolution operator is what we must exercise.
+        expect { eval("RelaxedUrlQuery::#{const}", binding, __FILE__, __LINE__) } # standard:disable Security/Eval
+          .to raise_error(NameError, /private constant/)
+      end
+    end
+
+    it "exposes no public constants at all" do
+      expect(RelaxedUrlQuery.constants(false)).to be_empty
+    end
+
+    # A pre-encoded String must never reach the relax step -- rejected explicitly,
+    # not by accident (mirrors the JS helper's TypeError).
+    ["sort=bez%2Cnr", "", "%2C"].each do |bad|
+      it "raises TypeError for the pre-built string #{bad.inspect}" do
+        expect { RelaxedUrlQuery.to_query(bad) }.to raise_error(TypeError, /expects a Hash/)
+      end
+    end
+
+    it "raises TypeError for nil / arrays / other non-hashes" do
+      [nil, ["a", "b"], 42, :sym].each do |bad|
+        expect { RelaxedUrlQuery.to_query(bad) }.to raise_error(TypeError, /expects a Hash/)
+      end
+    end
+  end
+end

--- a/spec/models/url_encoding_guard_spec.rb
+++ b/spec/models/url_encoding_guard_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026 German Contingent for the World Scout Jamboree 2027.
+#
+#  This file is part of hitobito_wsjrdp_2027 and licensed under the
+#  Affero General Public License version 3 or later. See the COPYING
+#  file at the top-level directory or at
+#  https://github.com/smeky42/hitobito_wsjrdp_2027
+
+# Enforces the encapsulation rule of doc/url_encoding.md §6: the %XX -> literal
+# "relax" replacement may exist ONLY inside the two mandatory helpers, because it
+# is safe only on the immediate output of a percent-encoder. Anywhere else it can
+# hit a string containing a raw "%" and corrupt data or forge separators.
+#
+# Standalone by design (no rails spec_helper, no DB) -- runs from the core app
+# directory inside the dev container:
+#   bundle exec rspec ../hitobito_wsjrdp_2027/spec/models/url_encoding_guard_spec.rb
+require "pathname"
+
+describe "URL-encoding guard (doc/url_encoding.md §6)" do
+  let(:wagon_root) { Pathname.new(File.expand_path("../..", __dir__)) }
+
+  # The only two places a %XX relax may appear. Widening this list is a policy
+  # change -- see doc/url_encoding.md §6.1.
+  let(:allowed) do
+    ["app/models/relaxed_url_query.rb",
+      "app/views/shared/_relaxed_query_js.html.haml"]
+  end
+
+  let(:scanned_globs) do
+    %w[app/**/*.rb app/**/*.haml app/**/*.erb app/**/*.js lib/**/*.rb lib/**/*.rake]
+  end
+
+  # A string/regexp replacement whose pattern starts with a percent escape, e.g.
+  # .gsub("%2C", ","), .replace(/%7E/gi, "~"), .tr('%2C', ',').
+  let(:relax_call) do
+    /\.(?:gsub|gsub!|sub|sub!|replace|tr|tr!)\s*\(?\s*(?:["']%[0-9A-Fa-f]{2}|\/%[0-9A-Fa-f]{2})/
+  end
+
+  # Comment lines -- the doc and call sites legitimately *describe* the pattern.
+  let(:comment) { /\A\s*(?:#|\/\/|-#|\*|<!--)/ }
+
+  def offending_lines(path, root)
+    path.read.lines.each_with_index.filter_map do |line, i|
+      next if line.match?(comment)
+      next unless line.match?(relax_call)
+      "#{path.relative_path_from(root)}:#{i + 1}: #{line.strip}"
+    end
+  rescue ArgumentError # binary / invalid encoding
+    []
+  end
+
+  it "finds no %XX relax outside the two mandatory helpers" do
+    files = scanned_globs.flat_map { |g| Pathname.glob(wagon_root.join(g)) }
+      .reject { |p| allowed.include?(p.relative_path_from(wagon_root).to_s) }
+
+    expect(files).not_to be_empty, "guard scanned nothing -- check WAGON_ROOT/globs"
+
+    offenders = files.flat_map { |p| offending_lines(p, wagon_root) }
+    expect(offenders).to be_empty, <<~MSG
+      Percent-escape replacement found outside the mandatory helpers:
+
+        #{offenders.join("\n  ")}
+
+      This is forbidden by doc/url_encoding.md §6: relaxing %XX is safe ONLY on
+      the immediate output of a percent-encoder. Use RelaxedUrlQuery.to_query
+      (Ruby) or window.wsjrdpRelaxedQuery (JS) instead. Adding a file to ALLOWED
+      is itself a policy change -- see doc/url_encoding.md §6.1.
+    MSG
+  end
+
+  # Guard the guard: a regex that no longer matches the real pattern would pass
+  # silently forever.
+  it "detects the forbidden pattern in representative samples" do
+    samples = [
+      'url.gsub("%2C", ",")',
+      "qs.replace(/%7E/gi, '~')",
+      'str.sub("%2c", ",")',
+      "x.gsub!(/%2C/, ',')"
+    ]
+    expect(samples.select { |s| s.match?(relax_call) }).to eq(samples)
+  end
+
+  it "does not flag comments or unrelated replacements" do
+    benign = [
+      "# decode %2C back to a comma",
+      '// .replace(/%2C/gi, ",") -- described in a comment',
+      'value.gsub("foo", "bar")',
+      'text.gsub(/\s+/, " ")'
+    ]
+    expect(benign.reject { |s| s.match?(comment) }.select { |s| s.match?(relax_call) }).to be_empty
+  end
+
+  it "keeps the allowlist minimal and pointing at existing files" do
+    expect(allowed.size).to eq(2)
+    allowed.each { |rel| expect(wagon_root.join(rel)).to exist }
+  end
+end


### PR DESCRIPTION
Query strings over-encode by default: every Ruby and JS encoder we use percent-encodes `,` and `~` although RFC 3986 permits both literally in a query and Rack never splits a value on them. The result is noisy URLs like `?sort=bez%2Cnr%7E` where `?sort=bez,nr~` is equally valid.

Relaxing the encoding means replacing `%XX` back to the literal character. That is safe ONLY on the immediate output of a percent-encoder, where a raw `%` is guaranteed to be escaped as `%25`. Therefore we use encapsulation to make encoding and relaxing inseparable.

  * `RelaxedUrlQuery.to_query(hash)` is the only Ruby entry point. It raises `TypeError` on anything but a Hash, and the relax table and pattern are `private_constant`, so the pieces cannot be reassembled into a raw-string from outside.
  * `window.wsjrdpRelaxedQuery` (`shared/_relaxed_query_js`) exposes `serialize()` and `href()`. Both reject plain strings. `href()` reassembles from URL components (never regexing path or fragment) and collapses a leading `//` so its result can never become a cross-origin network-path reference.

Both are covered by round-trip suites over raw `%`, the literal text `%2C/%7E` as data, separators, non-ASCII, nested params and a seeded 500-case fuzz, plus API-contract assertions. `url_encoding_guard_spec` fails the build if a `%XX` replacement appears anywhere outside these two helpers, and the JS suite now runs in CI (it needs neither the core, a bundle nor a database).

`doc/url_encoding.md` carries the policy, the measured encoder tables, the security rationale and the checklist for ever widening the relax set.